### PR TITLE
feat: add Discord webhook notification for negative call ratings

### DIFF
--- a/backend/src/routes/calls.ts
+++ b/backend/src/routes/calls.ts
@@ -14,6 +14,7 @@ import type {
 } from '../utils/types.js';
 import { resolveAllowedGarages } from '../utils/auth.js';
 import { sendNegativeFeedbackEmail, sendCallSummaryEmail } from '../utils/email.js';
+import { sendDiscordNotification, DISCORD_COLORS } from '../utils/discord.js';
 import { trackConfirmedBooking } from '../services/billing.js';
 
 const router = Router();
@@ -594,19 +595,40 @@ router.post(
         },
       });
 
-      // Send email notification for negative feedback
-      if (rating === 'down' && req.user?.email) {
-        void sendNegativeFeedbackEmail({
-          branchName: call.garage.name,
-          callId,
-          rating: 'down',
-          reasons: normalizedReasons,
-          notes: sanitizedNotes,
-          userEmail: req.user.email,
-          submittedAt: new Date().toISOString(),
+      // Send notifications for negative feedback
+      if (rating === 'down') {
+        const fields = [
+          { name: 'Branch', value: call.garage.name, inline: true },
+          { name: 'Call ID', value: callId, inline: true },
+          { name: 'Duration', value: call.durationSeconds ? `${call.durationSeconds}s` : 'n/a', inline: true },
+        ];
+        if (call.callType) fields.push({ name: 'Type', value: call.callType, inline: true });
+        if (call.customerPhone) fields.push({ name: 'Caller', value: call.customerPhone, inline: true });
+        if (normalizedReasons.length) fields.push({ name: 'Reasons', value: normalizedReasons.join(', '), inline: false });
+        if (sanitizedNotes) fields.push({ name: 'Notes', value: sanitizedNotes, inline: false });
+
+        void sendDiscordNotification({
+          title: 'Negative Call Rating',
+          description: `A call at **${call.garage.name}** was rated thumbs down.`,
+          color: DISCORD_COLORS.error,
+          fields,
         }).catch((error) => {
-          console.error('Failed to send negative feedback email:', error);
+          console.error('Failed to send Discord notification:', error);
         });
+
+        if (req.user?.email) {
+          void sendNegativeFeedbackEmail({
+            branchName: call.garage.name,
+            callId,
+            rating: 'down',
+            reasons: normalizedReasons,
+            notes: sanitizedNotes,
+            userEmail: req.user.email,
+            submittedAt: new Date().toISOString(),
+          }).catch((error) => {
+            console.error('Failed to send negative feedback email:', error);
+          });
+        }
       }
 
       res.json({ feedback: serializeCallFeedback(feedback) });

--- a/backend/src/utils/discord.ts
+++ b/backend/src/utils/discord.ts
@@ -1,0 +1,53 @@
+/**
+ * Discord webhook utility — sends formatted notifications to a Discord channel.
+ * Reads DISCORD_WEBHOOK_URL from env. If not set, silently skips.
+ */
+
+interface DiscordField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+interface DiscordEmbedOptions {
+  title: string;
+  description?: string;
+  color?: number;
+  fields?: DiscordField[];
+}
+
+// Colours matching the existing agent convention
+export const DISCORD_COLORS = {
+  error:   0xFF0000,
+  warning: 0xFFA500,
+  success: 0x00FF00,
+  info:    0x0099FF,
+};
+
+export async function sendDiscordNotification(options: DiscordEmbedOptions): Promise<void> {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+  if (!webhookUrl) return;
+
+  const body = {
+    embeds: [
+      {
+        title: options.title,
+        description: options.description ?? '',
+        color: options.color ?? DISCORD_COLORS.info,
+        fields: options.fields ?? [],
+        timestamp: new Date().toISOString(),
+        footer: { text: 'ReceptionMate Portal' },
+      },
+    ],
+  };
+
+  const res = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Discord webhook failed: ${res.status} ${res.statusText}`);
+  }
+}


### PR DESCRIPTION
- New discord.ts utility with sendDiscordNotification() matching the embed format already used by GarageHive/Tyresoft agents
- Fires on thumbs-down rating: branch name, call ID, duration, caller number, reasons, and notes included in embed
- Reads DISCORD_WEBHOOK_URL from env; silently skips if not set
- Email notification still sent alongside Discord