### PR TITLE
fix: remove invalid instagram_manage_messages OAuth scope

### DIFF
--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -26,7 +26,7 @@ router.post('/oauth/meta/initiate', authenticate, async (req: Request, res: Resp
     const scopes: Record<string, string> = {
       whatsapp: 'whatsapp_business_management,whatsapp_business_messaging',
       facebook: 'pages_messaging,pages_manage_metadata,pages_show_list,business_management',
-      instagram: 'instagram_basic,instagram_manage_messages,instagram_manage_comments,pages_messaging,pages_show_list,business_management',
+      instagram: 'instagram_basic,instagram_manage_comments,pages_messaging,pages_show_list,business_management',
     };
 
     const scope = scopes[platform];


### PR DESCRIPTION
## What
Removes `instagram_manage_messages` from the Instagram OAuth scope string.

## Why
This is not a valid Facebook Login OAuth scope — it caused "Invalid Scopes" error when reconnecting Instagram in the portal. Instagram DM messaging works through `pages_messaging` which is already in the scope list and approved.

## Deploy
Just `git pull && pm2 restart backend` — no DB changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)