### PR TITLE
feat: resend welcome email + change email address (admin) — closes #28, #23

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { isReceptionMateStaff } from '../lib/auth';
 import {
   activateGarage,
+  changeUserEmail,
   createAdminBranch,
   createAdminUser,
   deleteAdminBranch,
@@ -13,6 +14,7 @@ import {
   deleteAdminUser,
   fetchAdminBusinesses,
   fetchAdminUsers,
+  resendWelcomeEmail,
   updateBusinessContact,
   updateGarageTwilioNumber,
   updateAdminUser,
@@ -62,6 +64,11 @@ export default function AdminPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
   const [forecastDays, setForecastDays] = useState(30);
+  const [resendingEmail, setResendingEmail] = useState<Record<string, boolean>>({});
+  const [resendFeedback, setResendFeedback] = useState<Record<string, string>>({});
+  const [changeEmailTarget, setChangeEmailTarget] = useState<string | null>(null);
+  const [changeEmailForm, setChangeEmailForm] = useState({ newEmail: '', confirmEmail: '' });
+  const [changeEmailMessage, setChangeEmailMessage] = useState('');
 
   const adminStatus = useMemo(() => isReceptionMateStaff(), []);
 
@@ -466,6 +473,20 @@ export default function AdminPage() {
     },
   });
 
+  const changeEmailMutation = useMutation({
+    mutationFn: changeUserEmail,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['adminUsers'] });
+      setChangeEmailMessage('Email updated successfully.');
+      setChangeEmailTarget(null);
+      setChangeEmailForm({ newEmail: '', confirmEmail: '' });
+    },
+    onError: (error: any) => {
+      const msg = error?.response?.data?.error ?? 'Failed to update email.';
+      setChangeEmailMessage(msg);
+    },
+  });
+
   const assignmentMutation = useMutation({
     mutationFn: updateAdminUser,
     onSuccess: () => {
@@ -489,6 +510,19 @@ export default function AdminPage() {
       setUserMessage('Failed to unassign branch.');
     },
   });
+
+  const handleResendWelcomeEmail = async (user: AdminUser) => {
+    setResendingEmail((prev) => ({ ...prev, [user.id]: true }));
+    setResendFeedback((prev) => ({ ...prev, [user.id]: '' }));
+    try {
+      await resendWelcomeEmail(user.id);
+      setResendFeedback((prev) => ({ ...prev, [user.id]: 'Sent!' }));
+    } catch {
+      setResendFeedback((prev) => ({ ...prev, [user.id]: 'Failed to send.' }));
+    } finally {
+      setResendingEmail((prev) => ({ ...prev, [user.id]: false }));
+    }
+  };
 
   const handleAssign = (user: AdminUser) => {
     const target = assignmentTarget[user.id];
@@ -1357,6 +1391,67 @@ export default function AdminPage() {
                           ? accessDescriptions.join(', ')
                           : 'None yet. Assign branches to give visibility.'}
                       </p>
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          disabled={resendingEmail[user.id]}
+                          onClick={() => handleResendWelcomeEmail(user)}
+                          className="rounded-lg border border-sky-600 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.3em] text-sky-400 disabled:opacity-50"
+                        >
+                          {resendingEmail[user.id] ? 'Sending…' : 'Resend Welcome Email'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setChangeEmailTarget(changeEmailTarget === user.id ? null : user.id);
+                            setChangeEmailForm({ newEmail: '', confirmEmail: '' });
+                            setChangeEmailMessage('');
+                          }}
+                          className="rounded-lg border border-slate-600 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-400"
+                        >
+                          Change Email
+                        </button>
+                        {resendFeedback[user.id] && (
+                          <span className="text-[10px] text-slate-400">{resendFeedback[user.id]}</span>
+                        )}
+                      </div>
+                      {changeEmailTarget === user.id && (
+                        <div className="mt-3 space-y-2 border-t border-slate-800 pt-3">
+                          <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Change email address</p>
+                          <input
+                            type="email"
+                            placeholder="New email address"
+                            value={changeEmailForm.newEmail}
+                            onChange={(e) => setChangeEmailForm((prev) => ({ ...prev, newEmail: e.target.value }))}
+                            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-xs text-slate-100"
+                          />
+                          <input
+                            type="email"
+                            placeholder="Confirm new email address"
+                            value={changeEmailForm.confirmEmail}
+                            onChange={(e) => setChangeEmailForm((prev) => ({ ...prev, confirmEmail: e.target.value }))}
+                            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-xs text-slate-100"
+                          />
+                          {changeEmailMessage && (
+                            <p className="text-xs text-slate-400">{changeEmailMessage}</p>
+                          )}
+                          <button
+                            type="button"
+                            disabled={changeEmailMutation.isPending}
+                            onClick={() => {
+                              setChangeEmailMessage('');
+                              changeEmailMutation.mutate({
+                                userId: user.id,
+                                newEmail: changeEmailForm.newEmail.trim(),
+                                confirmEmail: changeEmailForm.confirmEmail.trim(),
+                              });
+                            }}
+                            className="rounded-lg bg-sky-500 px-3 py-1 text-xs font-semibold text-white transition-colors hover:bg-sky-400 disabled:opacity-50"
+                          >
+                            {changeEmailMutation.isPending ? 'Saving…' : 'Save email'}
+                          </button>
+                        </div>
+                      )}
                       {selectedBusiness && branches.length > 0 && (
                         <div className="mt-3 space-y-2 border-t border-slate-800 pt-3">
                           <label className="text-xs uppercase tracking-[0.3em] text-slate-500">

--- a/app/lib/admin.ts
+++ b/app/lib/admin.ts
@@ -96,6 +96,23 @@ export const updateGarageTwilioNumber = async (payload: { garageId: string; twil
   return data;
 };
 
+export const resendWelcomeEmail = async (userId: string): Promise<{ success: boolean }> => {
+  const { data } = await api.post<{ success: boolean }>(`/api/admin/users/${userId}/resend-welcome-email`);
+  return data;
+};
+
+export const changeUserEmail = async (payload: {
+  userId: string;
+  newEmail: string;
+  confirmEmail: string;
+}): Promise<{ user: AdminUser }> => {
+  const { data } = await api.patch<{ user: AdminUser }>(`/api/admin/users/${payload.userId}/email`, {
+    newEmail: payload.newEmail,
+    confirmEmail: payload.confirmEmail,
+  });
+  return data;
+};
+
 export const updateGarageMessagingAccess = async (payload: { garageId: string; hasMessagingAccess: boolean }) => {
   const { data } = await api.patch<{ hasMessagingAccess: boolean }>(
     `/garages/${payload.garageId}/messaging-access`,

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -903,4 +903,77 @@ router.post('/billing/trigger-invoice-generation', authenticate, requireAdmin, a
   }
 });
 
+// POST /api/admin/users/:userId/resend-welcome-email
+router.post('/admin/users/:userId/resend-welcome-email', authenticate, requireAdmin, async (req, res) => {
+  const { userId } = req.params;
+
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) {
+    return res.status(404).json({ error: 'User not found.' });
+  }
+
+  let businessName = 'ReceptionMate';
+  let branchName = user.email;
+
+  if (user.garageAccessIds.length > 0) {
+    const garage = await prisma.garage.findUnique({
+      where: { id: user.garageAccessIds[0] },
+      include: {
+        agentConfiguration: { select: { branchName: true } },
+        business: { select: { name: true } },
+      },
+    });
+    if (garage) {
+      businessName = garage.business?.name ?? businessName;
+      branchName = garage.agentConfiguration?.branchName ?? garage.name;
+    }
+  }
+
+  const portalUrl = process.env.PORTAL_URL || 'https://portal.receptionmate.co.uk';
+  await sendWelcomeEmail({
+    to: user.email,
+    businessName,
+    branchName,
+    email: user.email,
+    password: DEFAULT_PASSWORD,
+    portalUrl,
+  });
+
+  res.json({ success: true });
+});
+
+// PATCH /api/admin/users/:userId/email
+router.patch('/admin/users/:userId/email', authenticate, requireAdmin, async (req, res) => {
+  const { userId } = req.params;
+  const { newEmail, confirmEmail } = req.body as { newEmail?: string; confirmEmail?: string };
+
+  if (!newEmail || !confirmEmail) {
+    return res.status(400).json({ error: 'Both email fields are required.' });
+  }
+  if (newEmail !== confirmEmail) {
+    return res.status(400).json({ error: 'Email addresses do not match.' });
+  }
+
+  const emailParse = z.string().email().safeParse(newEmail);
+  if (!emailParse.success) {
+    return res.status(400).json({ error: 'Invalid email address.' });
+  }
+
+  const normalised = newEmail.toLowerCase();
+
+  const existing = await prisma.user.findFirst({
+    where: { email: normalised, NOT: { id: userId } },
+  });
+  if (existing) {
+    return res.status(409).json({ error: 'This email address is already in use.' });
+  }
+
+  const user = await prisma.user.update({
+    where: { id: userId },
+    data: { email: normalised },
+  });
+
+  res.json({ user: { id: user.id, email: user.email, role: user.role } });
+});
+
 export default router;


### PR DESCRIPTION
## Summary

- **#28 — Resend welcome email:** New `POST /api/admin/users/:userId/resend-welcome-email` endpoint. Fetches the user's garage to get `businessName`/`branchName`, then calls the existing `sendWelcomeEmail()` with `Nomoremissedcalls`. Button added to each user row in the admin panel.
- **#23 — Change email address:** New `PATCH /api/admin/users/:userId/email` endpoint. Validates both fields match, checks for duplicates, updates `User.email`. Inline form added to each user row (toggle with Change Email button).

Both are ReceptionMate staff (admin) only — guarded by existing `requireAdmin` middleware.

## Test plan

- [ ] Admin panel → find a user → click **Resend Welcome Email** → loading spinner → "Sent!" feedback → email arrives with correct garage name and `Nomoremissedcalls` password
- [ ] Admin panel → find a user → click **Change Email** → enter mismatched emails → save blocked with error
- [ ] Enter matching emails for an address already in use → `409` error shown inline
- [ ] Enter valid new email → saved → user row updates to new address
- [ ] `npx tsc --noEmit` passes on both frontend and backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)