### PR TITLE
fix(tyresoft): productItem flag + tyre quantity consolidation

### DIFF
--- a/backend/src/services/chatAgentTyresoft.ts
+++ b/backend/src/services/chatAgentTyresoft.ts
@@ -821,7 +821,16 @@ async function tsCreateBooking(
 
   if (tyreBasket.length > 0) {
     // Tyre booking — use stock number items (serviceID: 0)
-    items = tyreBasket.map(t => ({
+    // Consolidate duplicate stock numbers (sum quantities) before building items
+    const consolidatedTyres = tyreBasket.reduce((acc: Record<string, typeof tyreBasket[0]>, t) => {
+      if (acc[t.stockNumber]) {
+        acc[t.stockNumber] = { ...acc[t.stockNumber], quantity: acc[t.stockNumber].quantity + t.quantity };
+      } else {
+        acc[t.stockNumber] = { ...t };
+      }
+      return acc;
+    }, {});
+    items = Object.values(consolidatedTyres).map(t => ({
       saleLineID:                    0,
       productID:                     0,
       tyrecatID:                     0,
@@ -831,6 +840,7 @@ async function tsCreateBooking(
       shippingService:               false,
       incomeAccountID:               0,
       sequence:                      0,
+      productItem:                   true,
       itemCode:                      t.stockNumber,
       itemDescription:               t.description,
       recordedDescription:           '',
@@ -856,7 +866,7 @@ async function tsCreateBooking(
       changeInQtyAffectingPickList:  false,
       creditedAmount:                0,
     }));
-    console.log(`[TS_AGENT] Building tyre sale: ${tyreBasket.length} tyre line(s)`);
+    console.log(`[TS_AGENT] Building tyre sale: ${Object.keys(consolidatedTyres).length} consolidated line(s) from ${tyreBasket.length} basket item(s)`);
   } else {
     // Service booking — look up price from TYRESOFT_SERVICES by service ID
     items = (args.service_ids as number[]).map((sid) => {


### PR DESCRIPTION
## Summary
- Add `productItem: true` to tyre line items — Tyresoft requires this field to recognise items as product lines (not services)
- Consolidate duplicate stock-number entries: sum quantities into a single line rather than sending multiple qty=1 entries
- Quantity consolidation uses a `reduce` over `tyreBasket` keyed by `stockNumber` before building the API payload

## Changes
- `backend/src/services/chatAgentTyresoft.ts` — chat agent tyre item builder

## Related
- Closes #42 — Tyresoft reported: product lines not coming through correctly; items sent individually instead of with correct quantity

## Test plan
- [ ] Book 2 tyres of the same stock number — should appear as 1 line with qty=2 in Tyresoft
- [ ] Book a tyre — Tyresoft diary should show it as a product line (not a service)
- [ ] Service bookings unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)