### PR TITLE
fix: Add HUMAN_AGENT tag to Facebook and Instagram staff replies

### DIFF
--- a/backend/src/routes/conversations.ts
+++ b/backend/src/routes/conversations.ts
@@ -289,6 +289,8 @@ async function sendReplyToChannel(
       {
         recipient: { id: platformUserId },
         message: { text: message },
+        messaging_type: 'MESSAGE_TAG',
+        tag: 'HUMAN_AGENT',
       },
       {
         headers: {
@@ -308,6 +310,8 @@ async function sendReplyToChannel(
       {
         recipient: { id: platformUserId },
         message: { text: message },
+        messaging_type: 'MESSAGE_TAG',
+        tag: 'HUMAN_AGENT',
       },
       {
         headers: {


### PR DESCRIPTION
## Summary
- Staff replies via conversations inbox now send with `messaging_type: MESSAGE_TAG` + `tag: HUMAN_AGENT` for Facebook and Instagram
- This is required by Meta for the Human Agent permission — allows human agents to reply within 7 days (vs standard 24-hour window)
- No changes to WhatsApp (different API, different rules)

## Why
Meta App Review rejected the Human Agent permission because when reviewers logged in and tested, replies were sent as plain messages — the HUMAN_AGENT tag was missing, so the feature couldn't be verified.

## Files changed
- `backend/src/routes/conversations.ts` — added `messaging_type` and `tag` fields to Facebook and Instagram send payloads

## Test plan
- [ ] Staff sends a manual reply on a Facebook conversation → verify message arrives with HUMAN_AGENT tag
- [ ] Staff sends a manual reply on an Instagram conversation → verify message arrives with HUMAN_AGENT tag
- [ ] Resubmit Meta App Review for Human Agent permission

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)