### PR TITLE
fix(config): preserve integration credentials when switching agent scripts

### DIFF
--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -633,7 +633,8 @@ router.put(
       : createDefaultGarageHiveSettings();
 
     const rawTyresoft = data.tyresoftSettings ?? {};
-    // Tyresoft takes priority — if agentScript is tyresoft-agent and credentials provided, store them
+    // Tyresoft takes priority — if agentScript is tyresoft-agent and credentials provided, store them.
+    // If credentials are not provided in this save, fall back to existing saved config to avoid wiping it.
     const integrationProviderConfig: Prisma.InputJsonValue | null =
       resolvedAgentScript === 'tyresoft-agent' && rawTyresoft.tsWorkspace
         ? {
@@ -643,6 +644,8 @@ router.put(
             tsApiKey: typeof rawTyresoft.tsApiKey === 'string' ? rawTyresoft.tsApiKey.trim() : '',
             tsDepotId: rawTyresoft.tsDepotId != null ? Number(rawTyresoft.tsDepotId) : 1,
           }
+        : resolvedAgentScript === 'tyresoft-agent' && existingConfig?.integrationProviderConfig
+        ? existingConfig.integrationProviderConfig as Prisma.InputJsonValue
         : requestedProvider === 'garage_hive'
         ? {
             instanceUrl: garageHiveSettings.instanceUrl,
@@ -682,7 +685,7 @@ router.put(
 
     const existingConfig = await prisma.agentConfiguration.findUnique({
       where: { garageId },
-      select: { agentScript: true },
+      select: { agentScript: true, integrationProviderConfig: true },
     });
 
     const [configuration, garageRecord] = await Promise.all([


### PR DESCRIPTION
Closes #49

## Summary
- Fixes a bug where saving config without Tyresoft credentials would silently wipe previously saved Tyresoft workspace/username/password/depotId
- Root cause: `integrationProviderConfig` was recalculated from scratch on every save — if `tsWorkspace` was empty, it fell back to GarageHive config
- Fix: also fetch `integrationProviderConfig` in the pre-save lookup, and use it as fallback when `agentScript` is `tyresoft-agent` but no new credentials are submitted

## Behaviour
- **Before:** Switching agent type → save → Tyresoft credentials wiped
- **After:** Switching agent type → save → existing credentials preserved until explicitly overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)