### PR TITLE
fix(config): move existingConfig fetch before use — resolves TS build error

### DIFF
--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -632,6 +632,11 @@ router.put(
         })
       : createDefaultGarageHiveSettings();
 
+    const existingConfig = await prisma.agentConfiguration.findUnique({
+      where: { garageId },
+      select: { agentScript: true, integrationProviderConfig: true },
+    });
+
     const rawTyresoft = data.tyresoftSettings ?? {};
     // Tyresoft takes priority — if agentScript is tyresoft-agent and credentials provided, store them.
     // If credentials are not provided in this save, fall back to existing saved config to avoid wiping it.
@@ -682,11 +687,6 @@ router.put(
       enableSmsBookingLinks: data.enableSmsBookingLinks !== false,
       voice: data.voice || 'leah',
     };
-
-    const existingConfig = await prisma.agentConfiguration.findUnique({
-      where: { garageId },
-      select: { agentScript: true, integrationProviderConfig: true },
-    });
 
     const [configuration, garageRecord] = await Promise.all([
       prisma.agentConfiguration.upsert({


### PR DESCRIPTION
Follow-up to #48 / closes #49 properly.

The `existingConfig` DB fetch was placed after the `integrationProviderConfig` calculation that references it, causing TS2448/TS2454 build errors. Moved the fetch before the calculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)