### PR TITLE
fix(voice): Tyresoft voice agent production readiness

### DIFF
--- a/agent-tyresoft/Tyresoftsupervisor_receptionmate.py
+++ b/agent-tyresoft/Tyresoftsupervisor_receptionmate.py
@@ -54,7 +54,7 @@ from agent_infra import (
     match_full_service, normalize_vrn,
     format_vrm_for_speech, format_price_for_speech, format_date_for_speech,
     # Configuration loading
-    load_agent_config, apply_agent_configuration,
+    load_agent_config, apply_agent_configuration, AGENT_CUSTOM_RULES,
     format_time_for_speech, format_tyre_size_for_speech, format_brand_for_speech,
     format_vehicle_for_speech,
     sanitise_phone, sanitise_email,
@@ -308,7 +308,7 @@ def _build_system_prompt() -> str:
         f"  - {code}: {s['name']} ({s['price']} pounds)"
         for code, s in SERVICES.items()
     )
-    return f"""You are Leah, a friendly voice AI receptionist for Tyresoft Tyre Centre.
+    prompt = f"""You are Leah, a friendly voice AI receptionist for Tyresoft Tyre Centre.
 
 TODAY: {now.strftime('%A %d %B %Y')} | TIME: {now.strftime('%H:%M')} UK
 
@@ -378,6 +378,10 @@ Say "No worries, take your time" at most — then STOP and WAIT. Do NOT continue
 Do NOT try to answer rhetorical questions or self-talk. Do NOT give advice on finding their phone number.
 Do NOT assume they've answered YES or NO to your previous question — wait for a clear answer.
 """
+    # Append custom rules if configured for this garage
+    if AGENT_CUSTOM_RULES:
+        prompt += "\n\nCUSTOM RULES FROM GARAGE:\n" + AGENT_CUSTOM_RULES + "\n"
+    return prompt
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1234,6 +1238,15 @@ class TyresoftSupervisor(Agent):
 
         svc = SERVICES[code]
 
+        # VRN is required for ALL service bookings — vehicle must be linked
+        if not s.vrn_confirmed:
+            svc_name = svc['name']
+            return (
+                f"Vehicle registration required for {svc_name}. Need VRN before adding to basket.\n"
+                "Say: 'To get that booked in, I'll need your vehicle registration. Could you read that out for me?'\n"
+                "Then STOP. Wait for VRN."
+            )
+
         # Duplicate prevention: reject if same service already in basket
         for existing in s.basket_items:
             if existing.get("type") == "service" and existing.get("code") == code:
@@ -1682,16 +1695,28 @@ class TyresoftSupervisor(Agent):
                 vehicle_id = veh_result.get("vehicleID", 0)
                 s.vehicle_id = vehicle_id
 
-        # Step 3: Build sale items
+        # Step 3: Build sale items (consolidate duplicate tyre stock numbers)
         sale_items = []
+        tyre_consolidated: dict = {}
         for item in s.basket_items:
             if item["type"] == "tyre":
-                sale_items.append(build_tyre_item(
-                    stock_number=item.get("stock_number", ""),
-                    quantity=item.get("quantity", 1),
-                    unit_price=item.get("price", 0),
-                ))
-            elif item["type"] == "service":
+                key = item.get("stock_number", "")
+                if key in tyre_consolidated:
+                    tyre_consolidated[key]["quantity"] += item.get("quantity", 1)
+                else:
+                    tyre_consolidated[key] = {
+                        "stock_number": key,
+                        "quantity": item.get("quantity", 1),
+                        "price": item.get("price", 0),
+                    }
+        for tyre in tyre_consolidated.values():
+            sale_items.append(build_tyre_item(
+                stock_number=tyre["stock_number"],
+                quantity=tyre["quantity"],
+                unit_price=tyre["price"],
+            ))
+        for item in s.basket_items:
+            if item["type"] == "service":
                 svc = SERVICES.get(item.get("code"), {})
                 sale_items.append(build_service_item(
                     service_id=svc.get("service_id", 0),
@@ -2257,7 +2282,7 @@ async def entrypoint(ctx: JobContext):
                 agent=supervisor,
                 room_options=agents.room_io.RoomOptions(
                     audio_input=agents.room_io.AudioInputOptions(
-                        noise_cancellation=noise_cancellation.BVC(),
+                        noise_cancellation=noise_cancellation.BVCTelephony(),
                     ),
                 ),
             )

--- a/agent-tyresoft/agent_infra.py
+++ b/agent-tyresoft/agent_infra.py
@@ -152,7 +152,7 @@ def load_agent_config(garage_id: str) -> dict:
 
 def apply_agent_configuration(configuration: dict):
     """Apply loaded configuration to global variables."""
-    global AGENT_BRANCH_NAME, AGENT_GREETING_LINE, ELEVEN_VOICE_ID, ELEVEN_STABILITY, ELEVEN_SIMILARITY, ELEVEN_STYLE
+    global AGENT_BRANCH_NAME, AGENT_GREETING_LINE, AGENT_CUSTOM_RULES, ELEVEN_VOICE_ID, ELEVEN_STABILITY, ELEVEN_SIMILARITY, ELEVEN_STYLE
     global GARAGE_HOURS
     
     if not isinstance(configuration, dict):
@@ -182,6 +182,12 @@ def apply_agent_configuration(configuration: dict):
         AGENT_GREETING_LINE = greeting_line
         print(f"[APPLY_CONFIG] Greeting line: {greeting_line[:50]}...")
     
+    # Apply custom rules
+    custom_rules = (configuration.get("customRules") or "").strip()
+    if custom_rules:
+        AGENT_CUSTOM_RULES = custom_rules
+        print(f"[APPLY_CONFIG] Custom rules loaded ({len(custom_rules)} chars)")
+
     # Apply voice selection by name
     voice_name = configuration.get("voice")
     if voice_name and isinstance(voice_name, str):
@@ -262,6 +268,7 @@ ERROR_LOG_PATH = os.getenv(
 )
 AGENT_BRANCH_NAME = os.getenv("AGENT_BRANCH_NAME", "Tyresoft")
 AGENT_GREETING_LINE = os.getenv("AGENT_GREETING_LINE", "")
+AGENT_CUSTOM_RULES = ""  # Loaded from portal config
 GARAGE_HOURS: dict = {}  # Loaded from portal configuration
 
 # LiveKit Inference Gateway
@@ -1134,6 +1141,7 @@ def build_tyre_item(stock_number: str, quantity: int, unit_price: float) -> dict
         "productEANCode": "", "productManufacturerCode": "",
         "serviceID": 0,  # 0 = tyre item
         "shippingService": False, "incomeAccountID": 0, "sequence": 0,
+        "productItem": True,
         "itemCode": stock_number,
         "itemDescription": "", "recordedDescription": "",
         "technicianID": 0,


### PR DESCRIPTION
## Summary
Five fixes to bring the Tyresoft voice agent (`Tyresoftsupervisor_receptionmate.py` + `agent_infra.py`) to production quality.

### agent_infra.py
- **`productItem: True`** added to `build_tyre_item` — the Tyresoft API requires this flag to recognise tyre lines as product items (without it, tyres were being rejected)
- **Custom Rules support** — added `AGENT_CUSTOM_RULES` global; `apply_agent_configuration` now reads `customRules` from garage config and stores it; `_build_system_prompt` appends it to the prompt so per-garage instructions take effect at call start

### Tyresoftsupervisor_receptionmate.py
- **BVC → BVCTelephony** (#57) — upgraded noise cancellation to telephony-grade, matching GarageHive agent
- **VRN required for all services** (#58) — `add_service_to_basket` now blocks all service bookings (MOT, alignment, air con, puncture repair) if `vrn_confirmed` is False, not just full_service/tyres
- **Tyre quantity consolidation** — `submit_booking` now consolidates duplicate tyre stock numbers before building sale items, preventing double-line errors on the Tyresoft API

## Notes for Dan
- `nova-3` and `noise_cancellation` plugin were already in the code/requirements ✅
- After merging, the **LiveKit Cloud agent needs a redeploy** (Dockerfile → `Tyresoftsupervisor_receptionmate.py start`) to pick up the changes

## Test plan
- [ ] Call with MOT request — agent must ask for reg before getting timeslots
- [ ] Call with Full Service — reg required before engine size detection
- [ ] Call with tyre booking — 2x same tyre should create 1 line with qty=2
- [ ] Garage with Custom Rules set — rules should appear in agent behaviour
- [ ] Phone call quality — noise cancellation should be telephony-grade (BVCTelephony)

Closes #55 #56 #57 #58 #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)