### PR TITLE
fix(chat): service name, pleasantry response, question answering, clickable cards

### DIFF
--- a/app/widget/[garageId]/page.tsx
+++ b/app/widget/[garageId]/page.tsx
@@ -62,29 +62,29 @@ function renderMessageContent(content: string, primaryColor: string, isUser: boo
     };
   }).filter(Boolean) as { num: string; name: string; price?: string }[];
 
-  const clickable = !!onOptionClick;
-
   return (
     <>
       {intro && <p style={{ marginBottom: '10px', color: '#374151' }}>{intro}</p>}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
         {items.map((item) => (
-          <div
+          <button
             key={item.num}
-            onClick={clickable ? () => onOptionClick(item.num) : undefined}
+            onClick={onOptionClick ? () => onOptionClick(item.num) : undefined}
             style={{
               display: 'flex',
               alignItems: 'center',
               gap: '10px',
               padding: '9px 11px',
-              backgroundColor: clickable ? 'rgba(0,0,0,0.04)' : 'rgba(0,0,0,0.03)',
+              backgroundColor: 'rgba(0,0,0,0.03)',
               borderRadius: '10px',
-              border: `1px solid ${clickable ? 'rgba(0,0,0,0.12)' : 'rgba(0,0,0,0.07)'}`,
-              cursor: clickable ? 'pointer' : 'default',
+              border: '1px solid rgba(0,0,0,0.10)',
+              cursor: onOptionClick ? 'pointer' : 'default',
+              textAlign: 'left',
+              width: '100%',
               transition: 'background-color 0.15s',
             }}
-            onMouseEnter={clickable ? (e) => { (e.currentTarget as HTMLDivElement).style.backgroundColor = 'rgba(0,0,0,0.09)'; } : undefined}
-            onMouseLeave={clickable ? (e) => { (e.currentTarget as HTMLDivElement).style.backgroundColor = 'rgba(0,0,0,0.04)'; } : undefined}
+            onMouseEnter={onOptionClick ? (e) => { e.currentTarget.style.backgroundColor = 'rgba(0,0,0,0.09)'; } : undefined}
+            onMouseLeave={onOptionClick ? (e) => { e.currentTarget.style.backgroundColor = 'rgba(0,0,0,0.03)'; } : undefined}
           >
             <div style={{
               width: '22px', height: '22px', borderRadius: '50%',
@@ -96,7 +96,7 @@ function renderMessageContent(content: string, primaryColor: string, isUser: boo
               <div style={{ fontWeight: 500, fontSize: '13px', color: '#111827', lineHeight: '1.3' }}>{item.name}</div>
               {item.price && <div style={{ fontSize: '12px', color: '#6b7280', marginTop: '1px' }}>{item.price}</div>}
             </div>
-          </div>
+          </button>
         ))}
       </div>
     </>
@@ -441,7 +441,7 @@ export default function ChatWidget() {
                       msg.content,
                       config?.primaryColor || '#3f51b5',
                       msg.role === 'user',
-                      msg.role === 'assistant' && !sending ? (num) => sendMessage(num) : undefined
+                      msg.role === 'assistant' ? (num) => sendMessage(num) : undefined
                     )}
                   </div>
                 </div>

--- a/backend/src/services/chatAgentV2.ts
+++ b/backend/src/services/chatAgentV2.ts
@@ -447,8 +447,13 @@ export async function getChatAgentResponse(
     // Fast-path: booking already confirmed — don't re-enter contact collection
     if (session.step === Step.CONFIRMED || session.step === Step.DONE) {
       const nameGreet = session.customerNameFirst ? ` ${session.customerNameFirst}` : '';
-      if (message.trim().length > 5) {
-        session.notes = (session.notes ? session.notes + ' | ' : '') + `Post-booking: ${message.trim()}`;
+      const msg = message.trim();
+      const isPleasantry = /^(thanks|thank you|cheers|great|perfect|brilliant|sounds good|nice|cool|awesome|lovely|wonderful|ok|okay|brill|fab|fantastic)[\s!.]*$/i.test(msg);
+      if (isPleasantry) {
+        return { content: `You're welcome${nameGreet}! See you then! 👋`, needsHumanAssistance: false };
+      }
+      if (msg.length > 5) {
+        session.notes = (session.notes ? session.notes + ' | ' : '') + `Post-booking: ${msg}`;
         await saveSession(conversationId, session);
         return { content: `Thanks${nameGreet}! We'll make sure the team knows. See you soon! 👋`, needsHumanAssistance: false };
       }
@@ -484,8 +489,21 @@ export async function getChatAgentResponse(
           return { content: instructionToCustomerReply(instructions), needsHumanAssistance: false };
         }
 
-        // Question mid-collection — fall through to OpenAI so it can answer naturally
-        if (msg.includes('?')) { /* intentional fall-through */ }
+        // Question mid-collection — answer it with OpenAI mini then re-ask for the field
+        if (msg.includes('?')) {
+          const fieldNeeded = !session.contactPhone ? 'phone number'
+            : !session.contactEmail ? 'email address'
+            : !session.contactPostcode ? 'postcode'
+            : 'house number or name';
+          const miniSystemPrompt = buildSystemPromptV2(config, garage.knowledgeDocuments, isOpen, session);
+          const miniMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+            { role: 'system', content: `${miniSystemPrompt}\n\nIMPORTANT: The customer asked a question during contact collection. Answer it briefly (1 sentence max), then immediately re-ask for their ${fieldNeeded}. Be warm and natural. Do NOT call any tools.` },
+            ...previousMessages.map(m => ({ role: (m.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant', content: m.content })),
+            { role: 'user', content: msg },
+          ];
+          const miniResp = await getOpenAI().chat.completions.create({ model: 'gpt-4o-mini', temperature: 0.5, max_tokens: 120, messages: miniMessages });
+          return { content: miniResp.choices[0].message.content || `Could I also grab your ${fieldNeeded}?`, needsHumanAssistance: false };
+        }
         // Looks like a note — save it and re-ask for the missing field
         else if (msg.length > 10 && !/^(yes|no|yeah|yep|correct|sure|ok|okay|thanks|cheers)$/i.test(msg)) {
           session.notes = (session.notes ? session.notes + ' | ' : '') + `Customer note: ${msg}`;
@@ -1372,7 +1390,7 @@ async function handleSelectService(args: any, session: ChatSession, conversation
     await ghSetService(session.sessionId, String(serviceId));
     
     session.serviceSelectedId = String(serviceId);
-    session.serviceSelectedName = serviceName;
+    session.serviceSelectedName = cleanServiceName(serviceName);
     session.servicePrice = price;
     session.step = Step.NEED_TIMESLOT;
     
@@ -2036,6 +2054,15 @@ function formatTimeNaturally(timeStr: string): string {
   } else {
     return `${hour - 12}${min}pm`;
   }
+}
+
+// Strip GH API's " - component1 / component2 / ..." suffix from service names
+function cleanServiceName(name: string): string {
+  const dashIdx = name.indexOf(' - ');
+  if (dashIdx > 0 && name.substring(dashIdx + 3).includes(' / ')) {
+    return name.substring(0, dashIdx).trim();
+  }
+  return name;
 }
 
 function formatSlotsAsNumberedList(timeslots: any[], max = 3): string {


### PR DESCRIPTION
## Summary
- **Service name truncation**: GH API returns `"Full Service - change oil / change oild filter / c"` — now strips the component list to show `"Full Service"`
- **Pleasantry response**: "Thanks", "Cheers" etc. after booking now get `"You're welcome! See you then! 👋"` instead of `"We'll make sure the team knows"`
- **Question mid-contact**: Asking e.g. `"What's included in the MOT?"` during email/postcode collection now calls gpt-4o-mini to answer the question then immediately re-asks for the missing field
- **Clickable timeslot cards**: Changed option cards from `<div>` to `<button>` for native browser clickability; always pass click handler (sendMessage guards duplicate sends internally)

## Test plan
- [ ] Book a Full Service — service name shows as "Full Service" not the long component string
- [ ] After booking completes, type "Thanks" — Leah says "You're welcome! See you then!"
- [ ] During email collection, ask "What's included in the MOT?" — Leah answers then re-asks for email
- [ ] Timeslot cards are now tappable (click sends the number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)