### PR TITLE
fix(widget): slot cards show full text on click + intro header before slots

### DIFF
--- a/app/widget/[garageId]/page.tsx
+++ b/app/widget/[garageId]/page.tsx
@@ -69,7 +69,7 @@ function renderMessageContent(content: string, primaryColor: string, isUser: boo
         {items.map((item) => (
           <button
             key={item.num}
-            onClick={onOptionClick ? () => onOptionClick(item.num) : undefined}
+            onClick={onOptionClick ? () => onOptionClick(`${item.num}. ${item.name}`) : undefined}
             style={{
               display: 'flex',
               alignItems: 'center',

--- a/backend/src/services/chatAgentV2.ts
+++ b/backend/src/services/chatAgentV2.ts
@@ -1268,7 +1268,7 @@ async function handleSelectService(args: any, session: ChatSession, conversation
     const modelTitle = (session.vehicleModel || '').toLowerCase().split(' ').map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
     const priceNum = parseFloat(String(session.servicePrice));
     const priceDisplay = (!session.servicePrice || isNaN(priceNum) || priceNum < 1) ? 'POA' : `£${priceNum.toFixed(2).replace(/\.00$/, '')}`;
-    return `SERVICE_ALREADY_SET: ${session.serviceSelectedName} (${priceDisplay}).\nSay: "A ${session.serviceSelectedName} for your ${makeTitle} ${modelTitle} is ${priceDisplay}.\n\n${firstSlots}"\nWhen the customer responds, call select_timeslot with whatever they say.`;
+    return `SERVICE_ALREADY_SET: ${session.serviceSelectedName} (${priceDisplay}).\nSay: "A ${session.serviceSelectedName} for your ${makeTitle} ${modelTitle} is ${priceDisplay}.\n\nWhich of these slots works for you?\n${firstSlots}"\nWhen the customer responds, call select_timeslot with whatever they say.`;
   }
 
   console.log(`[SELECT_SERVICE] Looking for: ${service_name}`);
@@ -1447,7 +1447,7 @@ When the customer responds, call select_timeslot with whatever they say.`;
     }
 
     return `SERVICE_SET: ${serviceName} (${priceDisplay}).
-Say: "A ${serviceName} for your ${makeTitle} ${modelTitle} is ${priceDisplay}.\n\n${firstSlots}"
+Say: "A ${serviceName} for your ${makeTitle} ${modelTitle} is ${priceDisplay}.\n\nWhich of these slots works for you?\n${firstSlots}"
 When the customer responds, call select_timeslot with whatever they say.`;
     
   } catch (error: any) {
@@ -1473,7 +1473,7 @@ async function handleConfirmBooking(args: any, session: ChatSession, conversatio
   const firstSlots = formatSlotsAsNumberedList(session.timeslotsAvailable);
 
   return `SLOTS: Available timeslots below.
-Say: "${firstSlots}"
+Say: "Which of these slots works for you?\n${firstSlots}"
 When the customer responds, call select_timeslot with whatever they say.`;
 }
 


### PR DESCRIPTION
## Summary
- Clicking a slot card now sends `1. tomorrow at 8:30am` instead of just `1` — user bubble shows the actual selection
- All timeslot responses now include **"Which of these slots works for you?"** before the numbered list so users have context

🤖 Generated with [Claude Code](https://claude.com/claude-code)