### PR TITLE
fix(chat): note requests phrased as questions handled correctly

### DIFF
--- a/backend/src/services/chatAgentV2.ts
+++ b/backend/src/services/chatAgentV2.ts
@@ -489,8 +489,12 @@ export async function getChatAgentResponse(
           return { content: instructionToCustomerReply(instructions), needsHumanAssistance: false };
         }
 
-        // Question mid-collection — answer it with OpenAI mini then re-ask for the field
-        if (msg.includes('?')) {
+        // Note request phrased as a question ("Can you also note...", "Could you check...", "Please tell them...")
+        // — treat as a note regardless of the question mark
+        const isNoteRequest = /\b(can you (also |please )?(note|mention|tell them|check|flag|add|ask them|let them know|make a note)|could you (also |please )?(note|mention|tell them|check|flag)|please (also )?(note|mention|tell them|check|flag|add)|also (note|check|mention|add|flag|tell them)|let them know|make a note)\b/i.test(msg);
+
+        // Genuine question mid-collection — answer it with OpenAI mini then re-ask for the field
+        if (msg.includes('?') && !isNoteRequest) {
           const fieldNeeded = !session.contactPhone ? 'phone number'
             : !session.contactEmail ? 'email address'
             : !session.contactPostcode ? 'postcode'
@@ -504,7 +508,7 @@ export async function getChatAgentResponse(
           const miniResp = await getOpenAI().chat.completions.create({ model: 'gpt-4o-mini', temperature: 0.5, max_tokens: 120, messages: miniMessages });
           return { content: miniResp.choices[0].message.content || `Could I also grab your ${fieldNeeded}?`, needsHumanAssistance: false };
         }
-        // Looks like a note — save it and re-ask for the missing field
+        // Note or note-request — save it and re-ask for the missing field
         else if (msg.length > 10 && !/^(yes|no|yeah|yep|correct|sure|ok|okay|thanks|cheers)$/i.test(msg)) {
           session.notes = (session.notes ? session.notes + ' | ' : '') + `Customer note: ${msg}`;
           await saveSession(conversationId, session);


### PR DESCRIPTION
## Summary
'Can you also note...?' / 'Could you check the wipers?' etc. are now detected as note requests before the OpenAI mini question handler fires. Previously they hit the question path which hallucinated the wrong contact field to re-ask (e.g. asked for email address when email was already collected).

## Root cause
The `isNoteRequest` regex detects phrases like "can you note", "could you tell them", "also check" — even when the message ends in `?`. These go to the note-save + re-ask path, not the OpenAI mini path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)