### PR TITLE
fix(chat): timeslot fast-path now covers confirm_vehicle+serviceHint path

### DIFF
--- a/backend/src/services/chatAgentV2.ts
+++ b/backend/src/services/chatAgentV2.ts
@@ -663,8 +663,8 @@ export async function getChatAgentResponse(
           needContactFastPath = true;
         }
 
-        // If select_service just succeeded and transitioned to NEED_TIMESLOT, short-circuit
-        if (functionName === 'select_service' && (session.step as Step) === Step.NEED_TIMESLOT) {
+        // If select_service (or confirm_vehicle with serviceHint) transitioned to NEED_TIMESLOT, short-circuit
+        if ((functionName === 'select_service' || functionName === 'confirm_vehicle') && (session.step as Step) === Step.NEED_TIMESLOT) {
           const sayMatch = instructions.match(/Say:\s*"([\s\S]*?)"/i);
           if (sayMatch) {
             needTimeslotFastPath = true;


### PR DESCRIPTION
## Summary
When `serviceHint` is set, `confirm_vehicle` internally calls `handleSelectService` which transitions step to `NEED_TIMESLOT`. The fast-path check at line 667 only watched for `select_service`, so OpenAI received the slot list and paraphrased it as natural language — breaking numbered card rendering and click-to-select.

Now also triggers fast-path when `confirm_vehicle` transitions to `NEED_TIMESLOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)