### PR TITLE
feat: HubSpot CRM integration — call notifications to inbox

### DIFF
--- a/app/agent-configurations/page.tsx
+++ b/app/agent-configurations/page.tsx
@@ -20,6 +20,7 @@ import type {
   AgentKnowledgeDocument,
   AgentType,
   DayOfWeek,
+  HubspotSettings,
   IntegrationProvider,
   ResponseSpeed,
   TonePreference,
@@ -103,6 +104,16 @@ const cloneTyresoftSettings = (settings: TyresoftSettings | undefined): Tyresoft
   tsDepotId: settings?.tsDepotId ?? '',
 });
 
+const createEmptyHubspotSettings = (): HubspotSettings => ({
+  apiToken: '',
+  ownerId: '',
+});
+
+const cloneHubspotSettings = (settings: HubspotSettings | undefined): HubspotSettings => ({
+  apiToken: settings?.apiToken ?? '',
+  ownerId: settings?.ownerId ?? '',
+});
+
 const createEmptyConfiguration = (): AgentConfiguration => ({
   branchName: '',
   phoneNumber: '',
@@ -123,6 +134,7 @@ const createEmptyConfiguration = (): AgentConfiguration => ({
   integrationProvider: 'none',
   garageHiveSettings: createEmptyGarageHiveSettings(),
   tyresoftSettings: createEmptyTyresoftSettings(),
+  hubspotSettings: createEmptyHubspotSettings(),
   agentType: 'assist',
   agentScript: 'receptionmate-agent-v3',
   enableSmsBookingLinks: true,
@@ -136,6 +148,7 @@ const cloneConfiguration = (config: AgentConfiguration): AgentConfiguration => (
   weeklyOpeningHours: cloneWeeklyOpeningHours(config.weeklyOpeningHours),
   garageHiveSettings: cloneGarageHiveSettings(config.garageHiveSettings),
   tyresoftSettings: cloneTyresoftSettings(config.tyresoftSettings),
+  hubspotSettings: cloneHubspotSettings(config.hubspotSettings),
   dropOffExcludeServices: [...(config.dropOffExcludeServices || ['MOT'])],
 });
 
@@ -169,6 +182,11 @@ const integrationProviderOptions: { value: IntegrationProvider; label: string; d
     value: 'garage_hive',
     label: 'Garage Hive',
     description: 'Let the agent book straight into your Garage Hive diary.',
+  },
+  {
+    value: 'hubspot',
+    label: 'HubSpot',
+    description: 'Log every call as an engagement in your HubSpot CRM.',
   },
 ];
 
@@ -708,6 +726,23 @@ export default function AgentConfigurationsPage() {
       ...prev,
       tyresoftSettings: {
         ...prev.tyresoftSettings,
+        [field]: value,
+      },
+    }));
+    setFeedback(null);
+  };
+
+  const handleHubspotSettingsChange = (
+    field: keyof HubspotSettings,
+  ) => (event: ChangeEvent<HTMLInputElement>) => {
+    if (!isEditing || mutation.isPending) {
+      return;
+    }
+    const { value } = event.target;
+    setFormState((prev) => ({
+      ...prev,
+      hubspotSettings: {
+        ...prev.hubspotSettings,
         [field]: value,
       },
     }));
@@ -2016,6 +2051,82 @@ export default function AgentConfigurationsPage() {
                       <span className="text-xs uppercase tracking-wide text-slate-500">Location ID</span>
                       <div className="text-slate-100">
                         {formState.garageHiveSettings.locationId || 'Not set'}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )
+            ) : formState.integrationProvider === 'hubspot' ? (
+              isEditing ? (
+                <div className="flex flex-col gap-5">
+                  <div className="rounded-xl border border-sky-800/40 bg-sky-950/30 p-4 text-sm text-slate-300">
+                    <p className="mb-3 font-medium text-sky-300">How to set up your HubSpot Private App</p>
+                    <ol className="flex flex-col gap-2 text-slate-400 list-decimal list-inside">
+                      <li>Log in to HubSpot and go to <span className="text-slate-200">Settings</span> (top-right gear icon).</li>
+                      <li>In the left sidebar go to <span className="text-slate-200">Integrations → Private Apps</span>.</li>
+                      <li>Click <span className="text-slate-200">Create a private app</span>, give it a name (e.g. "ReceptionMate").</li>
+                      <li>Under the <span className="text-slate-200">Scopes</span> tab, enable these four scopes:
+                        <ul className="ml-5 mt-1 flex flex-col gap-1 list-disc">
+                          <li><code className="text-sky-300">crm.objects.contacts.read</code></li>
+                          <li><code className="text-sky-300">crm.objects.contacts.write</code></li>
+                          <li><code className="text-sky-300">crm.objects.tickets.write</code></li>
+                          <li><code className="text-sky-300">crm.objects.calls.write</code></li>
+                        </ul>
+                      </li>
+                      <li>Click <span className="text-slate-200">Create app</span>, then copy the token shown (starts with <code className="text-sky-300">pat-</code>).</li>
+                      <li>Paste it in the field below and save.</li>
+                    </ol>
+                    <p className="mt-3 text-xs text-slate-500">After saving, every inbound call will automatically create a contact and an inbox ticket in your HubSpot account.</p>
+                  </div>
+                  <div className="grid gap-5 md:grid-cols-2">
+                  <label className="flex flex-col gap-2 text-sm text-slate-300 md:col-span-2">
+                    <span className="text-xs uppercase tracking-wide text-slate-500">HubSpot Private App Token</span>
+                    <input
+                      type="password"
+                      placeholder="pat-na1-..."
+                      value={formState.hubspotSettings?.apiToken ?? ''}
+                      onChange={handleHubspotSettingsChange('apiToken')}
+                      disabled={!isEditing || mutation.isPending}
+                      required={formState.integrationProvider === 'hubspot'}
+                      className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                    />
+                    <span className="text-xs text-slate-500">
+                      Create a Private App in HubSpot (Settings → Integrations → Private Apps) with scopes: <code>crm.objects.contacts.read</code>, <code>crm.objects.contacts.write</code>, <code>crm.objects.tickets.write</code>, <code>crm.objects.calls.write</code>.
+                    </span>
+                  </label>
+                  <label className="flex flex-col gap-2 text-sm text-slate-300">
+                    <span className="text-xs uppercase tracking-wide text-slate-500">HubSpot Owner ID (optional)</span>
+                    <input
+                      type="text"
+                      placeholder="e.g. 11349275740"
+                      value={formState.hubspotSettings?.ownerId ?? ''}
+                      onChange={handleHubspotSettingsChange('ownerId')}
+                      disabled={!isEditing || mutation.isPending}
+                      className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                    />
+                    <span className="text-xs text-slate-500">
+                      Assign logged calls to a specific HubSpot user. Leave blank to log without an owner.
+                    </span>
+                  </label>
+                </div>
+                </div>
+              ) : (
+                <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-300">
+                  <div className="flex flex-col gap-3">
+                    <div>
+                      <span className="text-xs uppercase tracking-wide text-slate-500">System</span>
+                      <div className="text-slate-100">HubSpot CRM</div>
+                    </div>
+                    <div>
+                      <span className="text-xs uppercase tracking-wide text-slate-500">Private App Token</span>
+                      <div className="text-slate-100">
+                        {formState.hubspotSettings?.apiToken ? '••••••••' : 'Not set'}
+                      </div>
+                    </div>
+                    <div>
+                      <span className="text-xs uppercase tracking-wide text-slate-500">Owner ID</span>
+                      <div className="text-slate-100">
+                        {formState.hubspotSettings?.ownerId || 'Not set'}
                       </div>
                     </div>
                   </div>

--- a/app/agent-configurations/page.tsx
+++ b/app/agent-configurations/page.tsx
@@ -231,7 +231,6 @@ const voiceOptions: { value: VoiceOption; label: string; description: string; el
 
 export default function AgentConfigurationsPage() {
   const garageId = getGarageId();
-  const isStaff = isReceptionMateStaff();
   const [formState, setFormState] = useState<AgentConfiguration>(() => createEmptyConfiguration());
   const [isEditing, setIsEditing] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -2064,8 +2063,7 @@ export default function AgentConfigurationsPage() {
           </div>
         </section>
 
-        {isStaff && (
-          <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/30">
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/30">
             <h2 className="text-lg font-semibold text-slate-100">CRM Integration</h2>
             <p className="mt-1 text-sm text-slate-400">
               Connect a CRM so every inbound call automatically creates a contact record and an inbox ticket.
@@ -2157,7 +2155,6 @@ export default function AgentConfigurationsPage() {
               )}
             </div>
           </section>
-        )}
 
         <div className="flex justify-end">
           <button

--- a/app/agent-configurations/page.tsx
+++ b/app/agent-configurations/page.tsx
@@ -234,6 +234,10 @@ const voiceOptions: { value: VoiceOption; label: string; description: string; el
 
 export default function AgentConfigurationsPage() {
   const garageId = getGarageId();
+  const isStaff = isReceptionMateStaff();
+  const visibleIntegrationProviderOptions = integrationProviderOptions.filter(
+    (o) => o.value !== 'hubspot' || isStaff,
+  );
   const [formState, setFormState] = useState<AgentConfiguration>(() => createEmptyConfiguration());
   const [isEditing, setIsEditing] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -1950,14 +1954,14 @@ export default function AgentConfigurationsPage() {
                 disabled={!isEditing || mutation.isPending}
                 className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {integrationProviderOptions.map((option) => (
+                {visibleIntegrationProviderOptions.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>
                 ))}
               </select>
               <span className="text-xs text-slate-500">
-                {integrationProviderOptions.find((option) => option.value === formState.integrationProvider)?.description ?? ''}
+                {visibleIntegrationProviderOptions.find((option) => option.value === formState.integrationProvider)?.description ?? ''}
               </span>
             </label>
 

--- a/app/agent-configurations/page.tsx
+++ b/app/agent-configurations/page.tsx
@@ -105,11 +105,13 @@ const cloneTyresoftSettings = (settings: TyresoftSettings | undefined): Tyresoft
 });
 
 const createEmptyHubspotSettings = (): HubspotSettings => ({
+  enabled: false,
   apiToken: '',
   ownerId: '',
 });
 
 const cloneHubspotSettings = (settings: HubspotSettings | undefined): HubspotSettings => ({
+  enabled: settings?.enabled === true,
   apiToken: settings?.apiToken ?? '',
   ownerId: settings?.ownerId ?? '',
 });
@@ -183,11 +185,6 @@ const integrationProviderOptions: { value: IntegrationProvider; label: string; d
     label: 'Garage Hive',
     description: 'Let the agent book straight into your Garage Hive diary.',
   },
-  {
-    value: 'hubspot',
-    label: 'HubSpot',
-    description: 'Log every call as an engagement in your HubSpot CRM.',
-  },
 ];
 
 const agentTypeOptions: { value: AgentType; label: string; description: string }[] = [
@@ -235,9 +232,6 @@ const voiceOptions: { value: VoiceOption; label: string; description: string; el
 export default function AgentConfigurationsPage() {
   const garageId = getGarageId();
   const isStaff = isReceptionMateStaff();
-  const visibleIntegrationProviderOptions = integrationProviderOptions.filter(
-    (o) => o.value !== 'hubspot' || isStaff,
-  );
   const [formState, setFormState] = useState<AgentConfiguration>(() => createEmptyConfiguration());
   const [isEditing, setIsEditing] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -742,7 +736,7 @@ export default function AgentConfigurationsPage() {
     if (!isEditing || mutation.isPending) {
       return;
     }
-    const { value } = event.target;
+    const value = field === 'enabled' ? event.target.checked : event.target.value;
     setFormState((prev) => ({
       ...prev,
       hubspotSettings: {
@@ -1954,14 +1948,14 @@ export default function AgentConfigurationsPage() {
                 disabled={!isEditing || mutation.isPending}
                 className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {visibleIntegrationProviderOptions.map((option) => (
+                {integrationProviderOptions.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>
                 ))}
               </select>
               <span className="text-xs text-slate-500">
-                {visibleIntegrationProviderOptions.find((option) => option.value === formState.integrationProvider)?.description ?? ''}
+                {integrationProviderOptions.find((option) => option.value === formState.integrationProvider)?.description ?? ''}
               </span>
             </label>
 
@@ -2060,82 +2054,6 @@ export default function AgentConfigurationsPage() {
                   </div>
                 </div>
               )
-            ) : formState.integrationProvider === 'hubspot' ? (
-              isEditing ? (
-                <div className="flex flex-col gap-5">
-                  <div className="rounded-xl border border-sky-800/40 bg-sky-950/30 p-4 text-sm text-slate-300">
-                    <p className="mb-3 font-medium text-sky-300">How to set up your HubSpot Private App</p>
-                    <ol className="flex flex-col gap-2 text-slate-400 list-decimal list-inside">
-                      <li>Log in to HubSpot and go to <span className="text-slate-200">Settings</span> (top-right gear icon).</li>
-                      <li>In the left sidebar go to <span className="text-slate-200">Integrations → Private Apps</span>.</li>
-                      <li>Click <span className="text-slate-200">Create a private app</span>, give it a name (e.g. "ReceptionMate").</li>
-                      <li>Under the <span className="text-slate-200">Scopes</span> tab, enable these four scopes:
-                        <ul className="ml-5 mt-1 flex flex-col gap-1 list-disc">
-                          <li><code className="text-sky-300">crm.objects.contacts.read</code></li>
-                          <li><code className="text-sky-300">crm.objects.contacts.write</code></li>
-                          <li><code className="text-sky-300">crm.objects.tickets.write</code></li>
-                          <li><code className="text-sky-300">crm.objects.calls.write</code></li>
-                        </ul>
-                      </li>
-                      <li>Click <span className="text-slate-200">Create app</span>, then copy the token shown (starts with <code className="text-sky-300">pat-</code>).</li>
-                      <li>Paste it in the field below and save.</li>
-                    </ol>
-                    <p className="mt-3 text-xs text-slate-500">After saving, every inbound call will automatically create a contact and an inbox ticket in your HubSpot account.</p>
-                  </div>
-                  <div className="grid gap-5 md:grid-cols-2">
-                  <label className="flex flex-col gap-2 text-sm text-slate-300 md:col-span-2">
-                    <span className="text-xs uppercase tracking-wide text-slate-500">HubSpot Private App Token</span>
-                    <input
-                      type="password"
-                      placeholder="pat-na1-..."
-                      value={formState.hubspotSettings?.apiToken ?? ''}
-                      onChange={handleHubspotSettingsChange('apiToken')}
-                      disabled={!isEditing || mutation.isPending}
-                      required={formState.integrationProvider === 'hubspot'}
-                      className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                    />
-                    <span className="text-xs text-slate-500">
-                      Create a Private App in HubSpot (Settings → Integrations → Private Apps) with scopes: <code>crm.objects.contacts.read</code>, <code>crm.objects.contacts.write</code>, <code>crm.objects.tickets.write</code>, <code>crm.objects.calls.write</code>.
-                    </span>
-                  </label>
-                  <label className="flex flex-col gap-2 text-sm text-slate-300">
-                    <span className="text-xs uppercase tracking-wide text-slate-500">HubSpot Owner ID (optional)</span>
-                    <input
-                      type="text"
-                      placeholder="e.g. 11349275740"
-                      value={formState.hubspotSettings?.ownerId ?? ''}
-                      onChange={handleHubspotSettingsChange('ownerId')}
-                      disabled={!isEditing || mutation.isPending}
-                      className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                    />
-                    <span className="text-xs text-slate-500">
-                      Assign logged calls to a specific HubSpot user. Leave blank to log without an owner.
-                    </span>
-                  </label>
-                </div>
-                </div>
-              ) : (
-                <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-300">
-                  <div className="flex flex-col gap-3">
-                    <div>
-                      <span className="text-xs uppercase tracking-wide text-slate-500">System</span>
-                      <div className="text-slate-100">HubSpot CRM</div>
-                    </div>
-                    <div>
-                      <span className="text-xs uppercase tracking-wide text-slate-500">Private App Token</span>
-                      <div className="text-slate-100">
-                        {formState.hubspotSettings?.apiToken ? '••••••••' : 'Not set'}
-                      </div>
-                    </div>
-                    <div>
-                      <span className="text-xs uppercase tracking-wide text-slate-500">Owner ID</span>
-                      <div className="text-slate-100">
-                        {formState.hubspotSettings?.ownerId || 'Not set'}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )
             ) : (
               !isEditing && (
                 <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-300">
@@ -2145,6 +2063,101 @@ export default function AgentConfigurationsPage() {
             )}
           </div>
         </section>
+
+        {isStaff && (
+          <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/30">
+            <h2 className="text-lg font-semibold text-slate-100">CRM Integration</h2>
+            <p className="mt-1 text-sm text-slate-400">
+              Connect a CRM so every inbound call automatically creates a contact record and an inbox ticket.
+            </p>
+
+            <div className="mt-6 space-y-5">
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={formState.hubspotSettings?.enabled === true}
+                  onChange={handleHubspotSettingsChange('enabled')}
+                  disabled={!isEditing || mutation.isPending}
+                  className="h-4 w-4 rounded border-slate-600 bg-slate-800 text-sky-500 focus:ring-sky-500 disabled:cursor-not-allowed"
+                />
+                <span className="text-sm text-slate-300">Enable HubSpot CRM integration</span>
+              </label>
+
+              {formState.hubspotSettings?.enabled && (
+                isEditing ? (
+                  <div className="flex flex-col gap-5">
+                    <div className="rounded-xl border border-sky-800/40 bg-sky-950/30 p-4 text-sm text-slate-300">
+                      <p className="mb-3 font-medium text-sky-300">How to set up your HubSpot Private App</p>
+                      <ol className="flex flex-col gap-2 text-slate-400 list-decimal list-inside">
+                        <li>Log in to HubSpot and go to <span className="text-slate-200">Settings</span> (top-right gear icon).</li>
+                        <li>In the left sidebar go to <span className="text-slate-200">Integrations → Private Apps</span>.</li>
+                        <li>Click <span className="text-slate-200">Create a private app</span>, give it a name (e.g. "ReceptionMate").</li>
+                        <li>Under the <span className="text-slate-200">Scopes</span> tab, enable these four scopes:
+                          <ul className="ml-5 mt-1 flex flex-col gap-1 list-disc">
+                            <li><code className="text-sky-300">crm.objects.contacts.read</code></li>
+                            <li><code className="text-sky-300">crm.objects.contacts.write</code></li>
+                            <li><code className="text-sky-300">crm.objects.tickets.write</code></li>
+                            <li><code className="text-sky-300">crm.objects.calls.write</code></li>
+                          </ul>
+                        </li>
+                        <li>Click <span className="text-slate-200">Create app</span>, then copy the token shown (starts with <code className="text-sky-300">pat-</code>).</li>
+                        <li>Paste it in the field below and save.</li>
+                      </ol>
+                      <p className="mt-3 text-xs text-slate-500">After saving, every inbound call will automatically create a contact and an inbox ticket in your HubSpot account.</p>
+                    </div>
+                    <div className="grid gap-5 md:grid-cols-2">
+                      <label className="flex flex-col gap-2 text-sm text-slate-300 md:col-span-2">
+                        <span className="text-xs uppercase tracking-wide text-slate-500">HubSpot Private App Token</span>
+                        <input
+                          type="password"
+                          placeholder="pat-na1-..."
+                          value={formState.hubspotSettings?.apiToken ?? ''}
+                          onChange={handleHubspotSettingsChange('apiToken')}
+                          disabled={!isEditing || mutation.isPending}
+                          className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                        />
+                        <span className="text-xs text-slate-500">
+                          Create a Private App in HubSpot (Settings → Integrations → Private Apps) with scopes: <code>crm.objects.contacts.read</code>, <code>crm.objects.contacts.write</code>, <code>crm.objects.tickets.write</code>, <code>crm.objects.calls.write</code>.
+                        </span>
+                      </label>
+                      <label className="flex flex-col gap-2 text-sm text-slate-300">
+                        <span className="text-xs uppercase tracking-wide text-slate-500">HubSpot Owner ID (optional)</span>
+                        <input
+                          type="text"
+                          placeholder="e.g. 11349275740"
+                          value={formState.hubspotSettings?.ownerId ?? ''}
+                          onChange={handleHubspotSettingsChange('ownerId')}
+                          disabled={!isEditing || mutation.isPending}
+                          className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                        />
+                        <span className="text-xs text-slate-500">
+                          Assign logged calls to a specific HubSpot user. Leave blank to log without an owner.
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm text-slate-300">
+                    <div className="flex flex-col gap-3">
+                      <div>
+                        <span className="text-xs uppercase tracking-wide text-slate-500">Private App Token</span>
+                        <div className="text-slate-100">
+                          {formState.hubspotSettings?.apiToken ? maskSecretValue(formState.hubspotSettings.apiToken) : 'Not set'}
+                        </div>
+                      </div>
+                      <div>
+                        <span className="text-xs uppercase tracking-wide text-slate-500">Owner ID</span>
+                        <div className="text-slate-100">
+                          {formState.hubspotSettings?.ownerId || 'Not set'}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )
+              )}
+            </div>
+          </section>
+        )}
 
         <div className="flex justify-end">
           <button

--- a/app/components/MessagingSetupWizard.tsx
+++ b/app/components/MessagingSetupWizard.tsx
@@ -1,0 +1,438 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const DONE_KEY = 'rm_webchat_setup_done';
+const STEP_KEY = 'rm_webchat_setup_step';
+
+export function isWizardIncomplete(): boolean {
+  if (typeof window === 'undefined') return false;
+  return !localStorage.getItem(DONE_KEY);
+}
+
+export function getSavedStep(): number {
+  if (typeof window === 'undefined') return 0;
+  const saved = localStorage.getItem(STEP_KEY);
+  return saved ? parseInt(saved, 10) : 0;
+}
+
+interface Props {
+  onHide: () => void;
+  onDone: () => void;
+}
+
+// ── Reusable icon components ──────────────────────────────────────────────────
+
+const IconChat = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+  </svg>
+);
+
+const IconDeviceMobile = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+  </svg>
+);
+
+const IconBell = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+  </svg>
+);
+
+const IconPaint = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" />
+  </svg>
+);
+
+const IconCode = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+  </svg>
+);
+
+const IconLink = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+  </svg>
+);
+
+const IconCheck = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+);
+
+const IconFlag = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 21V4a1 1 0 011-1h14l-3 5 3 5H4" />
+  </svg>
+);
+
+const IconReply = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+  </svg>
+);
+
+const IconCog = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+  </svg>
+);
+
+const IconBook = ({ className }: { className?: string }) => (
+  <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+  </svg>
+);
+
+// WhatsApp logo mark
+const IconWhatsApp = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z" />
+    <path d="M12 0C5.373 0 0 5.373 0 12c0 2.123.554 4.118 1.528 5.845L.057 23.428a.5.5 0 00.515.572l5.75-1.507A11.945 11.945 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 21.818a9.818 9.818 0 01-5.006-1.373l-.36-.213-3.714.974.991-3.617-.234-.372A9.818 9.818 0 0112 2.182c5.428 0 9.818 4.39 9.818 9.818 0 5.429-4.39 9.818-9.818 9.818z" />
+  </svg>
+);
+
+// Facebook logo mark
+const IconFacebook = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M24 12.073C24 5.405 18.627 0 12 0S0 5.405 0 12.073c0 6.03 4.388 11.03 10.125 11.927v-8.437H7.078v-3.49h3.047V9.43c0-3.025 1.792-4.697 4.533-4.697 1.312 0 2.686.236 2.686.236v2.97h-1.513c-1.491 0-1.956.931-1.956 1.886v2.248h3.328l-.532 3.49h-2.796v8.437C19.612 23.103 24 18.103 24 12.073z" />
+  </svg>
+);
+
+// Instagram logo mark
+const IconInstagram = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z" />
+  </svg>
+);
+
+export default function MessagingSetupWizard({ onHide, onDone }: Props) {
+  const router = useRouter();
+  const [stepIndex, setStepIndex] = useState<number>(() => getSavedStep());
+
+  const goToStep = (index: number) => {
+    localStorage.setItem(STEP_KEY, String(index));
+    setStepIndex(index);
+  };
+
+  const navigateAway = (url: string) => {
+    onHide();
+    router.push(url);
+  };
+
+  const markDone = () => {
+    localStorage.setItem(DONE_KEY, '1');
+    localStorage.removeItem(STEP_KEY);
+    onDone();
+  };
+
+  const steps = [
+    {
+      id: 'welcome',
+      title: 'Welcome to Webchat',
+      subtitle: "ReceptionMate handles your customer conversations — let's get you set up in a few steps.",
+      headerIcon: <IconChat className="w-7 h-7 text-sky-400" />,
+      headerColor: 'bg-sky-500/10 border-sky-500/20',
+      content: (
+        <div className="space-y-4">
+          <p className="text-slate-300 text-sm leading-relaxed">
+            With ReceptionMate Webchat, your AI agent handles customer conversations on your website — answering questions, taking bookings, and handing off to your team when needed.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              { icon: <IconChat className="w-5 h-5 text-sky-400" />, bg: 'bg-sky-500/10 border-sky-500/20', label: 'AI-powered live chat on your website' },
+              { icon: <IconDeviceMobile className="w-5 h-5 text-violet-400" />, bg: 'bg-violet-500/10 border-violet-500/20', label: 'WhatsApp & social media in one inbox' },
+              { icon: <IconBell className="w-5 h-5 text-amber-400" />, bg: 'bg-amber-500/10 border-amber-500/20', label: 'Email alerts when customers need you' },
+            ].map((item, i) => (
+              <div key={i} className={`flex flex-col items-center gap-2.5 rounded-xl border ${item.bg} p-4 text-center`}>
+                <div className={`w-9 h-9 rounded-xl ${item.bg} border flex items-center justify-center flex-shrink-0`}>
+                  {item.icon}
+                </div>
+                <span className="text-xs text-slate-300 leading-snug">{item.label}</span>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-slate-500">
+            This wizard takes about 2 minutes. Close it at any time — your progress is saved and you can reopen it with the{' '}
+            <strong className="text-slate-400">Setup Guide</strong> button.
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: 'customize',
+      title: 'Brand Your Widget',
+      subtitle: 'Match the chat button to your website colours and logo.',
+      headerIcon: <IconPaint className="w-7 h-7 text-violet-400" />,
+      headerColor: 'bg-violet-500/10 border-violet-500/20',
+      content: (
+        <div className="space-y-4">
+          <p className="text-slate-300 text-sm leading-relaxed">
+            Open the widget customiser to set your brand colours, upload your logo, and choose a button icon that matches your website.
+          </p>
+          <ul className="space-y-2.5 text-sm text-slate-400">
+            {[
+              'Set your primary colour to match your brand',
+              'Upload your garage logo',
+              'Choose from chat bubble, WhatsApp, or phone icons',
+              'Preview exactly how it looks to your customers',
+            ].map(point => (
+              <li key={point} className="flex items-start gap-2.5">
+                <span className="mt-1.5 inline-block h-1.5 w-1.5 rounded-full bg-violet-400 flex-shrink-0" />
+                <span>{point}</span>
+              </li>
+            ))}
+          </ul>
+          <button
+            onClick={() => navigateAway('/integrations/widget/customize')}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium transition-colors"
+          >
+            <IconPaint className="w-4 h-4" />
+            Open Customiser
+          </button>
+        </div>
+      ),
+    },
+    {
+      id: 'embed',
+      title: 'Add to Your Website',
+      subtitle: 'Paste one snippet of code and the widget appears on your site.',
+      headerIcon: <IconCode className="w-7 h-7 text-emerald-400" />,
+      headerColor: 'bg-emerald-500/10 border-emerald-500/20',
+      content: (
+        <div className="space-y-4">
+          <p className="text-slate-300 text-sm leading-relaxed">
+            Copy your unique embed code from the <strong className="text-slate-200">Setup</strong> page and paste it into your
+            website — just before the closing{' '}
+            <code className="bg-slate-700/80 px-1.5 py-0.5 rounded text-xs font-mono text-slate-200">&lt;/body&gt;</code> tag.
+          </p>
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">Works on</p>
+            <div className="flex flex-wrap gap-2">
+              {['WordPress', 'Wix', 'Squarespace', 'GoHighLevel', 'Any HTML site'].map(platform => (
+                <span key={platform} className="px-3 py-1 rounded-full bg-slate-800 border border-slate-700 text-xs text-slate-300">
+                  {platform}
+                </span>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={() => navigateAway('/integrations/widget')}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium transition-colors"
+          >
+            <IconCode className="w-4 h-4" />
+            Get Embed Code
+          </button>
+        </div>
+      ),
+    },
+    {
+      id: 'connect',
+      title: 'Connect Social Platforms',
+      subtitle: 'Bring WhatsApp, Facebook Messenger, and Instagram into your inbox.',
+      headerIcon: <IconLink className="w-7 h-7 text-blue-400" />,
+      headerColor: 'bg-blue-500/10 border-blue-500/20',
+      content: (
+        <div className="space-y-4">
+          <p className="text-slate-300 text-sm leading-relaxed">
+            Connect your social media accounts so all customer messages from WhatsApp, Facebook, and Instagram arrive in the same Messages inbox.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {[
+              {
+                icon: <IconWhatsApp className="w-6 h-6" />,
+                iconBg: 'bg-[#25D366]/10 border-[#25D366]/25 text-[#25D366]',
+                name: 'WhatsApp',
+                desc: 'Business account',
+              },
+              {
+                icon: <IconFacebook className="w-6 h-6" />,
+                iconBg: 'bg-[#1877F2]/10 border-[#1877F2]/25 text-[#1877F2]',
+                name: 'Facebook',
+                desc: 'Page Messenger',
+              },
+              {
+                icon: <IconInstagram className="w-6 h-6" />,
+                iconBg: 'bg-pink-500/10 border-pink-500/25 text-pink-400',
+                name: 'Instagram',
+                desc: 'Business DMs',
+              },
+            ].map(p => (
+              <div key={p.name} className="flex flex-col items-center gap-2.5 rounded-xl border border-slate-700 bg-slate-800/50 p-4 text-center">
+                <div className={`w-10 h-10 rounded-xl border flex items-center justify-center ${p.iconBg}`}>
+                  {p.icon}
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-slate-200">{p.name}</p>
+                  <p className="text-xs text-slate-500">{p.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={() => navigateAway('/integrations')}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium transition-colors"
+          >
+            <IconLink className="w-4 h-4" />
+            Connect Platforms
+          </button>
+        </div>
+      ),
+    },
+    {
+      id: 'notifications',
+      title: 'Set Up Notifications',
+      subtitle: 'Make sure the right people are alerted when a customer needs attention.',
+      headerIcon: <IconBell className="w-7 h-7 text-amber-400" />,
+      headerColor: 'bg-amber-500/10 border-amber-500/20',
+      content: (
+        <div className="space-y-4">
+          <p className="text-slate-300 text-sm leading-relaxed">
+            Add email addresses in <strong className="text-slate-200">Agent Configurations</strong> to receive alerts whenever a conversation is flagged for human attention.
+          </p>
+          <ul className="space-y-2.5 text-sm text-slate-400">
+            {[
+              'Emails are sent when the AI flags a conversation, or when your team manually flags one',
+              'The email includes the last 3 messages and a direct link to the conversation',
+              'You can add multiple email addresses — great for team inboxes',
+            ].map(point => (
+              <li key={point} className="flex items-start gap-2.5">
+                <span className="mt-1.5 inline-block h-1.5 w-1.5 rounded-full bg-amber-400 flex-shrink-0" />
+                <span>{point}</span>
+              </li>
+            ))}
+          </ul>
+          <button
+            onClick={() => navigateAway('/agent-configurations')}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium transition-colors"
+          >
+            <IconCog className="w-4 h-4" />
+            Open Agent Configurations
+          </button>
+        </div>
+      ),
+    },
+    {
+      id: 'done',
+      title: "You're all set!",
+      subtitle: "Your webchat is ready to go. Here's a quick reminder of what you can do.",
+      headerIcon: <IconCheck className="w-7 h-7 text-emerald-400" />,
+      headerColor: 'bg-emerald-500/10 border-emerald-500/20',
+      content: (
+        <div className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              { icon: <IconFlag className="w-4 h-4 text-rose-400" />, bg: 'bg-rose-500/10 border-rose-500/20', title: 'Flag conversations', desc: 'Click the flag icon to alert your team and pause the AI' },
+              { icon: <IconReply className="w-4 h-4 text-sky-400" />, bg: 'bg-sky-500/10 border-sky-500/20', title: 'Reply manually', desc: 'Type in the message box to respond directly to customers' },
+              { icon: <IconCog className="w-4 h-4 text-violet-400" />, bg: 'bg-violet-500/10 border-violet-500/20', title: 'Human Escalation', desc: 'Toggle in Agent Configurations → Messaging & Connect Webchat' },
+              { icon: <IconBook className="w-4 h-4 text-amber-400" />, bg: 'bg-amber-500/10 border-amber-500/20', title: 'Full guide', desc: 'Help & Guides in the sidebar has everything in detail' },
+            ].map(item => (
+              <div key={item.title} className="flex items-start gap-3 rounded-xl border border-slate-700 bg-slate-800/50 p-3">
+                <div className={`w-8 h-8 rounded-lg border flex items-center justify-center flex-shrink-0 ${item.bg}`}>
+                  {item.icon}
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-slate-200">{item.title}</p>
+                  <p className="text-xs text-slate-500 mt-0.5 leading-snug">{item.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ),
+    },
+  ];
+
+  const step = steps[stepIndex];
+  const isLast = stepIndex === steps.length - 1;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="w-full max-w-lg rounded-2xl border border-slate-700/80 bg-slate-900 shadow-2xl shadow-black/60 flex flex-col">
+
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4 p-5 border-b border-slate-800">
+          <div className="flex items-center gap-3">
+            <div className={`flex items-center justify-center w-12 h-12 rounded-xl border flex-shrink-0 ${step.headerColor}`}>
+              {step.headerIcon}
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-slate-100">{step.title}</h2>
+              <p className="text-xs text-slate-400 mt-0.5 leading-snug max-w-xs">{step.subtitle}</p>
+            </div>
+          </div>
+          <button
+            onClick={onHide}
+            className="text-slate-500 hover:text-slate-300 transition-colors flex-shrink-0 mt-0.5 p-1 rounded-lg hover:bg-slate-800"
+            aria-label="Close"
+            title="Close — your progress is saved. Reopen with the Setup Guide button."
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Progress bar */}
+        <div className="flex gap-1.5 px-5 pt-4">
+          {steps.map((s, i) => (
+            <button
+              key={s.id}
+              onClick={() => goToStep(i)}
+              className={`h-1 flex-1 rounded-full transition-all duration-200 ${i <= stepIndex ? 'bg-sky-500' : 'bg-slate-700 hover:bg-slate-600'}`}
+              aria-label={`Go to step ${i + 1}: ${s.title}`}
+            />
+          ))}
+        </div>
+        <p className="px-5 pt-1.5 text-xs text-slate-600">
+          Step {stepIndex + 1} of {steps.length}
+        </p>
+
+        {/* Content */}
+        <div className="p-5 flex-1">{step.content}</div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between gap-3 px-5 pb-5 border-t border-slate-800 pt-4">
+          <button
+            onClick={markDone}
+            className="text-xs text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            Mark as done
+          </button>
+          <div className="flex items-center gap-2">
+            {stepIndex > 0 && (
+              <button
+                onClick={() => goToStep(stepIndex - 1)}
+                className="px-3.5 py-2 text-sm rounded-lg border border-slate-700 text-slate-300 hover:bg-slate-800 transition-colors"
+              >
+                Back
+              </button>
+            )}
+            {isLast ? (
+              <button
+                onClick={markDone}
+                className="px-4 py-2 text-sm rounded-lg bg-sky-600 hover:bg-sky-700 text-white font-medium transition-colors"
+              >
+                Finish Setup
+              </button>
+            ) : (
+              <button
+                onClick={() => goToStep(stepIndex + 1)}
+                className="px-4 py-2 text-sm rounded-lg bg-sky-600 hover:bg-sky-700 text-white font-medium transition-colors"
+              >
+                Next
+              </button>
+            )}
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -166,7 +166,7 @@ export const createEmptyWeeklyOpeningHours = (): WeeklyOpeningHours => {
   }, {} as WeeklyOpeningHours);
 };
 
-export type IntegrationProvider = 'none' | 'garage_hive' | 'hubspot';
+export type IntegrationProvider = 'none' | 'garage_hive';
 
 export type AgentType = 'assist' | 'automate';
 
@@ -180,6 +180,7 @@ export interface GarageHiveSettings {
 }
 
 export interface HubspotSettings {
+  enabled: boolean;
   apiToken: string;
   ownerId: string;
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -166,7 +166,7 @@ export const createEmptyWeeklyOpeningHours = (): WeeklyOpeningHours => {
   }, {} as WeeklyOpeningHours);
 };
 
-export type IntegrationProvider = 'none' | 'garage_hive';
+export type IntegrationProvider = 'none' | 'garage_hive' | 'hubspot';
 
 export type AgentType = 'assist' | 'automate';
 
@@ -177,6 +177,11 @@ export interface GarageHiveSettings {
   apiKey: string;
   customerId: string;
   locationId: string;
+}
+
+export interface HubspotSettings {
+  apiToken: string;
+  ownerId: string;
 }
 
 export interface TyresoftSettings {
@@ -207,6 +212,7 @@ export interface AgentConfiguration {
   integrationProvider: IntegrationProvider;
   garageHiveSettings: GarageHiveSettings;
   tyresoftSettings: TyresoftSettings;
+  hubspotSettings: HubspotSettings;
   agentType: AgentType;
   agentScript: 'receptionmate-agent' | 'receptionmate-agent-v3' | 'tyresoft-agent';
   enableSmsBookingLinks: boolean;

--- a/backend/src/routes/calls.ts
+++ b/backend/src/routes/calls.ts
@@ -257,13 +257,14 @@ router.post('/calls', async (req: Request, res: Response) => {
       }
     }
 
-    // Log to HubSpot if configured
-    if (createdCall.garage?.agentConfiguration?.integrationProvider === 'hubspot') {
-      const rawConfig = (createdCall.garage.agentConfiguration.integrationProviderConfig ?? {}) as Record<string, unknown>;
-      const rawHubspot = (rawConfig.hubspot && typeof rawConfig.hubspot === 'object')
-        ? rawConfig.hubspot as Record<string, unknown>
-        : rawConfig;
+    // Log to HubSpot if configured (independent of diary integrationProvider)
+    const rawConfig = (createdCall.garage?.agentConfiguration?.integrationProviderConfig ?? {}) as Record<string, unknown>;
+    const rawHubspot = (rawConfig.hubspot && typeof rawConfig.hubspot === 'object')
+      ? rawConfig.hubspot as Record<string, unknown>
+      : {};
+    if (rawHubspot.enabled === true && typeof rawHubspot.apiToken === 'string' && rawHubspot.apiToken) {
       const hubspotSettings = cloneHubspotSettings({
+        enabled: true,
         apiToken: typeof rawHubspot.apiToken === 'string' ? rawHubspot.apiToken : '',
         ownerId: typeof rawHubspot.ownerId === 'string' ? rawHubspot.ownerId : '',
       });
@@ -279,7 +280,7 @@ router.post('/calls', async (req: Request, res: Response) => {
         callType,
         confirmedBooking: payload.confirmedBooking ?? false,
         createdAt: createdCall.createdAt,
-        branchName: createdCall.garage.agentConfiguration.branchName,
+        branchName: createdCall.garage?.agentConfiguration?.branchName ?? '',
         recordingUrl: null, // recording URL not yet resolved at this point
       }, hubspotSettings).catch((error) => {
         console.error('[HUBSPOT] Failed to log call:', error);

--- a/backend/src/routes/calls.ts
+++ b/backend/src/routes/calls.ts
@@ -18,6 +18,8 @@ import { resolveAllowedGarages } from '../utils/auth.js';
 import { sendNegativeFeedbackEmail, sendCallSummaryEmail, sendPaymentSetupReminderEmail } from '../utils/email.js';
 import { sendDiscordNotification, DISCORD_COLORS } from '../utils/discord.js';
 import { trackConfirmedBooking } from '../services/billing.js';
+import { logCallToHubSpot } from '../services/hubspot.js';
+import { cloneHubspotSettings } from '../utils/types.js';
 
 const router = Router();
 
@@ -237,6 +239,8 @@ router.post('/calls', async (req: Request, res: Response) => {
               select: {
                 branchName: true,
                 notificationEmails: true,
+                integrationProvider: true,
+                integrationProviderConfig: true,
               },
             },
           },
@@ -251,6 +255,35 @@ router.post('/calls', async (req: Request, res: Response) => {
       } catch (error) {
         console.error('[BILLING] Failed to track confirmed booking:', error);
       }
+    }
+
+    // Log to HubSpot if configured
+    if (createdCall.garage?.agentConfiguration?.integrationProvider === 'hubspot') {
+      const rawConfig = (createdCall.garage.agentConfiguration.integrationProviderConfig ?? {}) as Record<string, unknown>;
+      const rawHubspot = (rawConfig.hubspot && typeof rawConfig.hubspot === 'object')
+        ? rawConfig.hubspot as Record<string, unknown>
+        : rawConfig;
+      const hubspotSettings = cloneHubspotSettings({
+        apiToken: typeof rawHubspot.apiToken === 'string' ? rawHubspot.apiToken : '',
+        ownerId: typeof rawHubspot.ownerId === 'string' ? rawHubspot.ownerId : '',
+      });
+
+      void logCallToHubSpot({
+        customerPhone: payload.customerPhone ?? null,
+        fromNumber: payload.fromNumber ?? null,
+        customerName: payload.customerName ?? null,
+        registrationNumber: payload.registrationNumber ?? null,
+        summary: payload.summary ?? null,
+        bookingDetails: payload.bookingDetails ?? null,
+        durationSeconds: actualDuration,
+        callType,
+        confirmedBooking: payload.confirmedBooking ?? false,
+        createdAt: createdCall.createdAt,
+        branchName: createdCall.garage.agentConfiguration.branchName,
+        recordingUrl: null, // recording URL not yet resolved at this point
+      }, hubspotSettings).catch((error) => {
+        console.error('[HUBSPOT] Failed to log call:', error);
+      });
     }
 
     // Send notification email (agent already filtered to only send calls >= 30s)

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -97,7 +97,7 @@ const parseIntegrationSettings = (
   providerValue: string | null | undefined,
   rawSettings: Prisma.JsonValue | null | undefined,
   agentScript?: string | null,
-): { integrationProvider: IntegrationProvider; garageHiveSettings: GarageHiveSettings; tyresoftSettings: TyresoftSettings; hubspotSettings: HubspotSettings } => {
+): { integrationProvider: IntegrationProvider; garageHiveSettings: GarageHiveSettings; tyresoftSettings: TyresoftSettings } => {
   const outer = (rawSettings && typeof rawSettings === 'object' && !Array.isArray(rawSettings))
     ? rawSettings as Record<string, unknown>
     : {};
@@ -110,7 +110,6 @@ const parseIntegrationSettings = (
     return {
       integrationProvider: 'none',
       garageHiveSettings: createDefaultGarageHiveSettings(),
-      hubspotSettings: createDefaultHubspotSettings(),
       tyresoftSettings: cloneTyresoftSettings({
         tsWorkspace: typeof raw.tsWorkspace === 'string' ? raw.tsWorkspace : (typeof raw.workspace === 'string' ? raw.workspace : ''),
         tsUsername: typeof raw.tsUsername === 'string' ? raw.tsUsername : (typeof raw.username === 'string' ? raw.username : ''),
@@ -121,32 +120,13 @@ const parseIntegrationSettings = (
     };
   }
 
-  const provider: IntegrationProvider =
-    providerValue === 'garage_hive' ? 'garage_hive' :
-    providerValue === 'hubspot' ? 'hubspot' :
-    'none';
-
-  if (provider === 'hubspot') {
-    const raw = (outer.hubspot && typeof outer.hubspot === 'object')
-      ? outer.hubspot as Record<string, unknown>
-      : outer;
-    return {
-      integrationProvider: 'hubspot',
-      garageHiveSettings: createDefaultGarageHiveSettings(),
-      tyresoftSettings: createDefaultTyresoftSettings(),
-      hubspotSettings: cloneHubspotSettings({
-        apiToken: typeof raw.apiToken === 'string' ? raw.apiToken : '',
-        ownerId: typeof raw.ownerId === 'string' ? raw.ownerId : '',
-      }),
-    };
-  }
+  const provider: IntegrationProvider = providerValue === 'garage_hive' ? 'garage_hive' : 'none';
 
   if (provider !== 'garage_hive') {
     return {
       integrationProvider: 'none',
       garageHiveSettings: createDefaultGarageHiveSettings(),
       tyresoftSettings: createDefaultTyresoftSettings(),
-      hubspotSettings: createDefaultHubspotSettings(),
     };
   }
 
@@ -164,8 +144,23 @@ const parseIntegrationSettings = (
       locationId: typeof settingsRecord.locationId === 'string' ? settingsRecord.locationId : '',
     }),
     tyresoftSettings: createDefaultTyresoftSettings(),
-    hubspotSettings: createDefaultHubspotSettings(),
   };
+};
+
+/** Parses HubSpot settings from integrationProviderConfig.hubspot — independent of diary provider */
+const parseHubspotSettings = (rawSettings: Prisma.JsonValue | null | undefined): HubspotSettings => {
+  if (!rawSettings || typeof rawSettings !== 'object' || Array.isArray(rawSettings)) {
+    return createDefaultHubspotSettings();
+  }
+  const outer = rawSettings as Record<string, unknown>;
+  const raw = (outer.hubspot && typeof outer.hubspot === 'object')
+    ? outer.hubspot as Record<string, unknown>
+    : {};
+  return cloneHubspotSettings({
+    enabled: raw.enabled === true,
+    apiToken: typeof raw.apiToken === 'string' ? raw.apiToken : '',
+    ownerId: typeof raw.ownerId === 'string' ? raw.ownerId : '',
+  });
 };
 
 const defaultConfiguration: AgentConfigurationPayload = {
@@ -194,16 +189,11 @@ const sanitizeConfigForResponse = (config: AgentConfigurationPayload) => {
   const weeklyOpeningHours = config.weeklyOpeningHours
     ? cloneWeeklyOpeningHours(config.weeklyOpeningHours)
     : createDefaultWeeklyOpeningHours();
-  const sanitizedProvider: IntegrationProvider =
-    config.integrationProvider === 'garage_hive' ? 'garage_hive' :
-    config.integrationProvider === 'hubspot' ? 'hubspot' :
-    'none';
+  const sanitizedProvider: IntegrationProvider = config.integrationProvider === 'garage_hive' ? 'garage_hive' : 'none';
   const garageHiveSettings = sanitizedProvider === 'garage_hive'
     ? cloneGarageHiveSettings(config.garageHiveSettings)
     : createDefaultGarageHiveSettings();
-  const hubspotSettings = sanitizedProvider === 'hubspot'
-    ? cloneHubspotSettings(config.hubspotSettings)
-    : createDefaultHubspotSettings();
+  const hubspotSettings = cloneHubspotSettings(config.hubspotSettings);
 
   return {
     ...config,
@@ -283,6 +273,7 @@ const buildConfigurationResponse = (configuration: PrismaAgentConfiguration | nu
       configuration.integrationProviderConfig,
       configuration.agentScript,
     ),
+    hubspotSettings: parseHubspotSettings(configuration.integrationProviderConfig),
   });
 };
 
@@ -651,7 +642,6 @@ router.put(
 
     const requestedProvider: IntegrationProvider =
       data.integrationProvider === 'garage_hive' ? 'garage_hive' :
-      data.integrationProvider === 'hubspot' ? 'hubspot' :
       'none';
     const rawGarageHive = data.garageHiveSettings ?? {};
     const garageHiveSettings = requestedProvider === 'garage_hive'
@@ -702,18 +692,20 @@ router.put(
         }
       : (existingGh.instanceUrl ? existingGh : null);  // keep existing garagehive creds if already saved
 
-    // HubSpot block — only update if new API token submitted, otherwise keep existing
+    // HubSpot block — independent of diary integrationProvider; always saved when token present
     const existingHs = (existingRaw.hubspot && typeof existingRaw.hubspot === 'object')
       ? existingRaw.hubspot as Record<string, unknown>
       : {} as Record<string, unknown>;
     const rawHubspot = data.hubspotSettings ?? {};
+    const hubspotEnabled = rawHubspot.enabled === true;
     const newHsApiToken = typeof rawHubspot.apiToken === 'string' ? rawHubspot.apiToken.trim() : '';
-    const hubspotBlock = (requestedProvider === 'hubspot' && newHsApiToken)
+    const hubspotBlock = newHsApiToken
       ? {
+          enabled:  hubspotEnabled,
           apiToken: newHsApiToken,
           ownerId:  typeof rawHubspot.ownerId === 'string' ? rawHubspot.ownerId.trim() : '',
         }
-      : (requestedProvider === 'hubspot' && existingHs.apiToken ? existingHs : null);
+      : (existingHs.apiToken ? { ...existingHs, enabled: hubspotEnabled } : null);
 
     const integrationProviderConfig: Prisma.InputJsonValue | null =
       (tyresoftBlock || garageHiveBlock || hubspotBlock)

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -9,15 +9,18 @@ import { resolveAllowedGarages } from '../utils/auth.js';
 import { upsertAgentConfigurationSchema, weeklyOpeningHoursSchema, websiteScanSchema } from '../utils/validators.js';
 import {
   cloneGarageHiveSettings,
+  cloneHubspotSettings,
   cloneTyresoftSettings,
   cloneWeeklyOpeningHours,
   createDefaultGarageHiveSettings,
+  createDefaultHubspotSettings,
   createDefaultTyresoftSettings,
   createDefaultWeeklyOpeningHours,
 } from '../utils/types.js';
 import type {
   AgentConfigurationPayload,
   GarageHiveSettings,
+  HubspotSettings,
   IntegrationProvider,
   ResponseSpeed,
   TyresoftSettings,
@@ -94,49 +97,63 @@ const parseIntegrationSettings = (
   providerValue: string | null | undefined,
   rawSettings: Prisma.JsonValue | null | undefined,
   agentScript?: string | null,
-): { integrationProvider: IntegrationProvider; garageHiveSettings: GarageHiveSettings; tyresoftSettings: TyresoftSettings } => {
+): { integrationProvider: IntegrationProvider; garageHiveSettings: GarageHiveSettings; tyresoftSettings: TyresoftSettings; hubspotSettings: HubspotSettings } => {
+  const outer = (rawSettings && typeof rawSettings === 'object' && !Array.isArray(rawSettings))
+    ? rawSettings as Record<string, unknown>
+    : {};
+
   // Tyresoft agent takes priority — check agentScript first regardless of integrationProvider
   if (agentScript === 'tyresoft-agent') {
-    if (rawSettings && typeof rawSettings === 'object' && !Array.isArray(rawSettings)) {
-      const raw = rawSettings as Record<string, unknown>;
-      return {
-        integrationProvider: 'none',
-        garageHiveSettings: createDefaultGarageHiveSettings(),
-        tyresoftSettings: cloneTyresoftSettings({
-          tsWorkspace: typeof raw.tsWorkspace === 'string' ? raw.tsWorkspace : (typeof raw.workspace === 'string' ? raw.workspace : ''),
-          tsUsername: typeof raw.tsUsername === 'string' ? raw.tsUsername : (typeof raw.username === 'string' ? raw.username : ''),
-          tsPassword: typeof raw.tsPassword === 'string' ? raw.tsPassword : (typeof raw.password === 'string' ? raw.password : ''),
-          tsApiKey: typeof raw.tsApiKey === 'string' ? raw.tsApiKey : (typeof raw.apiKey === 'string' ? raw.apiKey : ''),
-          tsDepotId: raw.tsDepotId != null ? String(raw.tsDepotId) : (raw.depotId != null ? String(raw.depotId) : ''),
-        }),
-      };
-    }
+    const raw = (outer.tyresoft && typeof outer.tyresoft === 'object')
+      ? outer.tyresoft as Record<string, unknown>
+      : outer;
     return {
       integrationProvider: 'none',
       garageHiveSettings: createDefaultGarageHiveSettings(),
-      tyresoftSettings: createDefaultTyresoftSettings(),
+      hubspotSettings: createDefaultHubspotSettings(),
+      tyresoftSettings: cloneTyresoftSettings({
+        tsWorkspace: typeof raw.tsWorkspace === 'string' ? raw.tsWorkspace : (typeof raw.workspace === 'string' ? raw.workspace : ''),
+        tsUsername: typeof raw.tsUsername === 'string' ? raw.tsUsername : (typeof raw.username === 'string' ? raw.username : ''),
+        tsPassword: typeof raw.tsPassword === 'string' ? raw.tsPassword : (typeof raw.password === 'string' ? raw.password : ''),
+        tsApiKey: typeof raw.tsApiKey === 'string' ? raw.tsApiKey : (typeof raw.apiKey === 'string' ? raw.apiKey : ''),
+        tsDepotId: raw.tsDepotId != null ? String(raw.tsDepotId) : (raw.depotId != null ? String(raw.depotId) : ''),
+      }),
     };
   }
 
-  const provider: IntegrationProvider = providerValue === 'garage_hive' ? 'garage_hive' : 'none';
+  const provider: IntegrationProvider =
+    providerValue === 'garage_hive' ? 'garage_hive' :
+    providerValue === 'hubspot' ? 'hubspot' :
+    'none';
+
+  if (provider === 'hubspot') {
+    const raw = (outer.hubspot && typeof outer.hubspot === 'object')
+      ? outer.hubspot as Record<string, unknown>
+      : outer;
+    return {
+      integrationProvider: 'hubspot',
+      garageHiveSettings: createDefaultGarageHiveSettings(),
+      tyresoftSettings: createDefaultTyresoftSettings(),
+      hubspotSettings: cloneHubspotSettings({
+        apiToken: typeof raw.apiToken === 'string' ? raw.apiToken : '',
+        ownerId: typeof raw.ownerId === 'string' ? raw.ownerId : '',
+      }),
+    };
+  }
 
   if (provider !== 'garage_hive') {
     return {
       integrationProvider: 'none',
       garageHiveSettings: createDefaultGarageHiveSettings(),
       tyresoftSettings: createDefaultTyresoftSettings(),
+      hubspotSettings: createDefaultHubspotSettings(),
     };
   }
 
-  if (!rawSettings || typeof rawSettings !== 'object' || Array.isArray(rawSettings)) {
-    return {
-      integrationProvider: 'garage_hive',
-      garageHiveSettings: createDefaultGarageHiveSettings(),
-      tyresoftSettings: createDefaultTyresoftSettings(),
-    };
-  }
-
-  const settingsRecord = rawSettings as Record<string, unknown>;
+  // garage_hive
+  const settingsRecord = (outer.garagehive && typeof outer.garagehive === 'object')
+    ? outer.garagehive as Record<string, unknown>
+    : outer;
 
   return {
     integrationProvider: 'garage_hive',
@@ -147,6 +164,7 @@ const parseIntegrationSettings = (
       locationId: typeof settingsRecord.locationId === 'string' ? settingsRecord.locationId : '',
     }),
     tyresoftSettings: createDefaultTyresoftSettings(),
+    hubspotSettings: createDefaultHubspotSettings(),
   };
 };
 
@@ -176,10 +194,16 @@ const sanitizeConfigForResponse = (config: AgentConfigurationPayload) => {
   const weeklyOpeningHours = config.weeklyOpeningHours
     ? cloneWeeklyOpeningHours(config.weeklyOpeningHours)
     : createDefaultWeeklyOpeningHours();
-  const sanitizedProvider: IntegrationProvider = config.integrationProvider === 'garage_hive' ? 'garage_hive' : 'none';
+  const sanitizedProvider: IntegrationProvider =
+    config.integrationProvider === 'garage_hive' ? 'garage_hive' :
+    config.integrationProvider === 'hubspot' ? 'hubspot' :
+    'none';
   const garageHiveSettings = sanitizedProvider === 'garage_hive'
     ? cloneGarageHiveSettings(config.garageHiveSettings)
     : createDefaultGarageHiveSettings();
+  const hubspotSettings = sanitizedProvider === 'hubspot'
+    ? cloneHubspotSettings(config.hubspotSettings)
+    : createDefaultHubspotSettings();
 
   return {
     ...config,
@@ -202,6 +226,7 @@ const sanitizeConfigForResponse = (config: AgentConfigurationPayload) => {
     notificationEmails: Array.isArray(config.notificationEmails) ? config.notificationEmails : [],
     integrationProvider: sanitizedProvider,
     garageHiveSettings,
+    hubspotSettings,
     agentType: config.agentType === 'automate' ? 'automate' : 'assist',
     agentScript: 
       config.agentScript === 'tyresoft-agent' ? 'tyresoft-agent' :
@@ -624,7 +649,10 @@ router.put(
       ? cloneWeeklyOpeningHours(data.weeklyOpeningHours)
       : createDefaultWeeklyOpeningHours();
 
-    const requestedProvider: IntegrationProvider = data.integrationProvider === 'garage_hive' ? 'garage_hive' : 'none';
+    const requestedProvider: IntegrationProvider =
+      data.integrationProvider === 'garage_hive' ? 'garage_hive' :
+      data.integrationProvider === 'hubspot' ? 'hubspot' :
+      'none';
     const rawGarageHive = data.garageHiveSettings ?? {};
     const garageHiveSettings = requestedProvider === 'garage_hive'
       ? cloneGarageHiveSettings({
@@ -645,27 +673,56 @@ router.put(
     });
 
     const rawTyresoft = data.tyresoftSettings ?? {};
-    // Tyresoft takes priority — if agentScript is tyresoft-agent and credentials provided, store them.
-    // If credentials are not provided in this save, fall back to existing saved config to avoid wiping it.
+    // Merge credentials into namespaced keys so switching agents never wipes the other agent's config.
+    // Both tyresoft and garagehive creds live inside the same JSON under separate keys.
+    const existingRaw = (existingConfig?.integrationProviderConfig ?? {}) as Record<string, unknown>;
+
+    // Tyresoft block — only update if new credentials are submitted, otherwise keep existing
+    const existingTs = (existingRaw.tyresoft ?? existingRaw) as Record<string, unknown>;
+    const newTsWorkspace = typeof rawTyresoft.tsWorkspace === 'string' ? rawTyresoft.tsWorkspace.trim() : '';
+    const tyresoftBlock = newTsWorkspace
+      ? {
+          tsWorkspace: newTsWorkspace,
+          tsUsername:  typeof rawTyresoft.tsUsername === 'string' ? rawTyresoft.tsUsername.trim() : '',
+          tsPassword:  typeof rawTyresoft.tsPassword === 'string' ? rawTyresoft.tsPassword.trim() : '',
+          tsApiKey:    typeof rawTyresoft.tsApiKey   === 'string' ? rawTyresoft.tsApiKey.trim()   : '',
+          tsDepotId:   rawTyresoft.tsDepotId != null ? Number(rawTyresoft.tsDepotId) : 1,
+        }
+      : (existingTs.tsWorkspace ? existingTs : null);  // keep existing tyresoft creds if already saved
+
+    // GarageHive block — only update if new credentials are submitted, otherwise keep existing
+    const existingGh = (existingRaw.garagehive ?? existingRaw) as Record<string, unknown>;
+    const newGhInstanceUrl = garageHiveSettings.instanceUrl;
+    const garageHiveBlock = (requestedProvider === 'garage_hive' && newGhInstanceUrl)
+      ? {
+          instanceUrl: garageHiveSettings.instanceUrl,
+          apiKey:      garageHiveSettings.apiKey,
+          customerId:  garageHiveSettings.customerId,
+          locationId:  garageHiveSettings.locationId,
+        }
+      : (existingGh.instanceUrl ? existingGh : null);  // keep existing garagehive creds if already saved
+
+    // HubSpot block — only update if new API token submitted, otherwise keep existing
+    const existingHs = (existingRaw.hubspot && typeof existingRaw.hubspot === 'object')
+      ? existingRaw.hubspot as Record<string, unknown>
+      : {} as Record<string, unknown>;
+    const rawHubspot = data.hubspotSettings ?? {};
+    const newHsApiToken = typeof rawHubspot.apiToken === 'string' ? rawHubspot.apiToken.trim() : '';
+    const hubspotBlock = (requestedProvider === 'hubspot' && newHsApiToken)
+      ? {
+          apiToken: newHsApiToken,
+          ownerId:  typeof rawHubspot.ownerId === 'string' ? rawHubspot.ownerId.trim() : '',
+        }
+      : (requestedProvider === 'hubspot' && existingHs.apiToken ? existingHs : null);
+
     const integrationProviderConfig: Prisma.InputJsonValue | null =
-      resolvedAgentScript === 'tyresoft-agent' && rawTyresoft.tsWorkspace
+      (tyresoftBlock || garageHiveBlock || hubspotBlock)
         ? {
-            tsWorkspace: typeof rawTyresoft.tsWorkspace === 'string' ? rawTyresoft.tsWorkspace.trim() : '',
-            tsUsername: typeof rawTyresoft.tsUsername === 'string' ? rawTyresoft.tsUsername.trim() : '',
-            tsPassword: typeof rawTyresoft.tsPassword === 'string' ? rawTyresoft.tsPassword.trim() : '',
-            tsApiKey: typeof rawTyresoft.tsApiKey === 'string' ? rawTyresoft.tsApiKey.trim() : '',
-            tsDepotId: rawTyresoft.tsDepotId != null ? Number(rawTyresoft.tsDepotId) : 1,
-          }
-        : resolvedAgentScript === 'tyresoft-agent' && existingConfig?.integrationProviderConfig
-        ? existingConfig.integrationProviderConfig as Prisma.InputJsonValue
-        : requestedProvider === 'garage_hive'
-        ? {
-            instanceUrl: garageHiveSettings.instanceUrl,
-            apiKey: garageHiveSettings.apiKey,
-            customerId: garageHiveSettings.customerId,
-            locationId: garageHiveSettings.locationId,
-          }
-        : null;
+            ...(tyresoftBlock   ? { tyresoft:   tyresoftBlock   as Prisma.InputJsonObject } : {}),
+            ...(garageHiveBlock ? { garagehive: garageHiveBlock as Prisma.InputJsonObject } : {}),
+            ...(hubspotBlock    ? { hubspot:    hubspotBlock    as Prisma.InputJsonObject } : {}),
+          } as Prisma.InputJsonObject
+        : existingConfig?.integrationProviderConfig ?? null;
 
     const normalizedData = {
       branchName: data.branchName,

--- a/backend/src/services/hubspot.ts
+++ b/backend/src/services/hubspot.ts
@@ -1,0 +1,249 @@
+import type { HubspotSettings } from '../utils/types.js';
+
+const HUBSPOT_API_BASE = 'https://api.hubapi.com';
+
+// Call disposition GUIDs (HubSpot standard)
+const DISPOSITION_CONNECTED = 'f240bbac-87c9-4f6e-bf70-924b57d47db7';
+
+export interface HubSpotCallData {
+  customerPhone: string | null;
+  fromNumber: string | null;
+  customerName: string | null;
+  registrationNumber: string | null;
+  summary: string | null;
+  bookingDetails: string | null;
+  durationSeconds: number;
+  callType: string;
+  confirmedBooking: boolean;
+  createdAt: Date;
+  branchName: string;
+  recordingUrl?: string | null;
+}
+
+const hubspotFetch = async (
+  path: string,
+  apiToken: string,
+  options: RequestInit = {},
+): Promise<Response> => {
+  return fetch(`${HUBSPOT_API_BASE}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+      ...(options.headers ?? {}),
+    },
+  });
+};
+
+/**
+ * Finds a HubSpot contact ID by phone number.
+ * Returns null if not found or on error.
+ */
+const findContactByPhone = async (phone: string, apiToken: string): Promise<string | null> => {
+  try {
+    const response = await hubspotFetch('/crm/v3/objects/contacts/search', apiToken, {
+      method: 'POST',
+      body: JSON.stringify({
+        filterGroups: [
+          { filters: [{ propertyName: 'phone', operator: 'EQ', value: phone }] },
+        ],
+        properties: ['id'],
+        limit: 1,
+      }),
+    });
+
+    if (!response.ok) return null;
+
+    const data = await response.json() as { results?: Array<{ id: string }> };
+    return data.results?.[0]?.id ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Creates a new HubSpot contact with available caller details.
+ * Returns the new contact ID, or null on failure.
+ */
+const createContact = async (call: HubSpotCallData, apiToken: string): Promise<string | null> => {
+  try {
+    const phone = call.customerPhone || call.fromNumber;
+    const properties: Record<string, string> = {};
+
+    if (phone) properties.phone = phone;
+
+    if (call.customerName) {
+      const parts = call.customerName.trim().split(/\s+/);
+      properties.firstname = parts[0];
+      if (parts.length > 1) properties.lastname = parts.slice(1).join(' ');
+    }
+
+    if (Object.keys(properties).length === 0) return null;
+
+    const response = await hubspotFetch('/crm/v3/objects/contacts', apiToken, {
+      method: 'POST',
+      body: JSON.stringify({ properties }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      console.error(`[HUBSPOT] Failed to create contact: ${response.status} ${text}`);
+      return null;
+    }
+
+    const data = await response.json() as { id: string };
+    console.log(`[HUBSPOT] Created new contact ${data.id}`);
+    return data.id;
+  } catch (err) {
+    console.error('[HUBSPOT] Error creating contact:', err);
+    return null;
+  }
+};
+
+/**
+ * Creates a HubSpot ticket (appears in inbox, like a form submission).
+ * Associates it with the contact if contactId is provided.
+ */
+const createTicket = async (
+  call: HubSpotCallData,
+  contactId: string | null,
+  ownerId: string,
+  apiToken: string,
+): Promise<string | null> => {
+  const phone = call.customerPhone || call.fromNumber || 'Unknown';
+  const subject = call.confirmedBooking
+    ? `Booking confirmed — ${call.customerName || phone} (${call.branchName})`
+    : `Inbound call — ${call.customerName || phone} (${call.branchName})`;
+
+  const lines: string[] = [];
+  lines.push(`Branch: ${call.branchName}`);
+  lines.push(`Phone: ${phone}`);
+  if (call.customerName) lines.push(`Name: ${call.customerName}`);
+  if (call.registrationNumber) lines.push(`Vehicle Registration: ${call.registrationNumber}`);
+  lines.push(`Call Type: ${call.callType || 'Unknown'}`);
+  lines.push(`Duration: ${Math.round(call.durationSeconds / 60)}m ${call.durationSeconds % 60}s`);
+  if (call.confirmedBooking) lines.push(`Booking Confirmed: Yes`);
+  if (call.bookingDetails) lines.push(`\nBooking Details:\n${call.bookingDetails}`);
+  if (call.summary) lines.push(`\nCall Summary:\n${call.summary}`);
+
+  const properties: Record<string, string> = {
+    subject,
+    content: lines.join('\n'),
+    hs_ticket_priority: call.confirmedBooking ? 'HIGH' : 'MEDIUM',
+    hs_pipeline: '0',        // default support pipeline
+    hs_pipeline_stage: '1',  // New
+  };
+
+  if (ownerId) properties.hubspot_owner_id = ownerId;
+
+  const associations = contactId
+    ? [
+        {
+          to: { id: contactId },
+          types: [{ associationCategory: 'HUBSPOT_DEFINED', associationTypeId: 16 }], // Ticket → Contact
+        },
+      ]
+    : undefined;
+
+  const response = await hubspotFetch('/crm/v3/objects/tickets', apiToken, {
+    method: 'POST',
+    body: JSON.stringify({ properties, ...(associations ? { associations } : {}) }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    console.error(`[HUBSPOT] Failed to create ticket: ${response.status} ${text}`);
+    return null;
+  }
+
+  const result = await response.json() as { id: string };
+  console.log(`[HUBSPOT] Ticket created: ${result.id}`);
+  return result.id;
+};
+
+/**
+ * Logs a call engagement on the contact's timeline.
+ */
+const logCallEngagement = async (
+  call: HubSpotCallData,
+  contactId: string | null,
+  ownerId: string,
+  apiToken: string,
+): Promise<void> => {
+  const durationMs = call.durationSeconds * 1000;
+  const phone = call.customerPhone || call.fromNumber;
+
+  const properties: Record<string, string> = {
+    hs_timestamp: call.createdAt.toISOString(),
+    hs_call_title: `${call.branchName} — ${call.callType || 'Inbound call'}${call.confirmedBooking ? ' (booking confirmed)' : ''}`,
+    hs_call_body: call.summary ?? '',
+    hs_call_direction: 'INBOUND',
+    hs_call_status: 'COMPLETED',
+    hs_call_duration: String(durationMs),
+    hs_call_from_number: phone ?? '',
+    hs_call_disposition: DISPOSITION_CONNECTED,
+    hs_call_source: 'INTEGRATIONS_PLATFORM',
+  };
+
+  if (ownerId) properties.hubspot_owner_id = ownerId;
+  if (call.recordingUrl) properties.hs_call_recording_url = call.recordingUrl;
+
+  const associations = contactId
+    ? [
+        {
+          to: { id: contactId },
+          types: [{ associationCategory: 'HUBSPOT_DEFINED', associationTypeId: 194 }], // Call → Contact
+        },
+      ]
+    : undefined;
+
+  const response = await hubspotFetch('/crm/v3/objects/calls', apiToken, {
+    method: 'POST',
+    body: JSON.stringify({ properties, ...(associations ? { associations } : {}) }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    console.error(`[HUBSPOT] Failed to log call engagement: ${response.status} ${text}`);
+  }
+};
+
+/**
+ * Main entry point: upserts a contact, creates an inbox ticket, and logs a call engagement.
+ *
+ * Required Private App scopes:
+ *   crm.objects.contacts.read
+ *   crm.objects.contacts.write
+ *   crm.objects.tickets.write
+ *   crm.objects.calls.write
+ */
+export const logCallToHubSpot = async (
+  call: HubSpotCallData,
+  settings: HubspotSettings,
+): Promise<void> => {
+  const { apiToken, ownerId } = settings;
+  if (!apiToken) {
+    console.error('[HUBSPOT] No API token configured — skipping');
+    return;
+  }
+
+  const callerPhone = call.customerPhone || call.fromNumber;
+
+  // 1. Find or create the contact
+  let contactId: string | null = null;
+  if (callerPhone) {
+    contactId = await findContactByPhone(callerPhone, apiToken);
+    if (contactId) {
+      console.log(`[HUBSPOT] Found existing contact ${contactId} for ${callerPhone}`);
+    } else {
+      console.log(`[HUBSPOT] No contact found for ${callerPhone} — creating new contact`);
+      contactId = await createContact(call, apiToken);
+    }
+  }
+
+  // 2. Create inbox ticket (visible in HubSpot inbox, like a form submission)
+  await createTicket(call, contactId, ownerId, apiToken);
+
+  // 3. Log call engagement on the contact timeline
+  await logCallEngagement(call, contactId, ownerId, apiToken);
+};

--- a/backend/src/utils/types.ts
+++ b/backend/src/utils/types.ts
@@ -46,7 +46,7 @@ export type WeeklyOpeningHours = Record<DayOfWeek, DailyOpeningHours>;
 
 export type ResponseSpeed = 'slow' | 'normal' | 'fast';
 
-export type IntegrationProvider = 'none' | 'garage_hive' | 'hubspot';
+export type IntegrationProvider = 'none' | 'garage_hive';
 
 export type AgentType = 'assist' | 'automate';
 
@@ -77,16 +77,19 @@ export const cloneTyresoftSettings = (settings?: TyresoftSettings | null): Tyres
 });
 
 export type HubspotSettings = {
+  enabled: boolean;
   apiToken: string;
   ownerId: string;
 };
 
 export const createDefaultHubspotSettings = (): HubspotSettings => ({
+  enabled: false,
   apiToken: '',
   ownerId: '',
 });
 
 export const cloneHubspotSettings = (settings?: HubspotSettings | null): HubspotSettings => ({
+  enabled: settings?.enabled === true,
   apiToken: typeof settings?.apiToken === 'string' ? settings.apiToken : '',
   ownerId: typeof settings?.ownerId === 'string' ? settings.ownerId : '',
 });

--- a/backend/src/utils/types.ts
+++ b/backend/src/utils/types.ts
@@ -46,7 +46,7 @@ export type WeeklyOpeningHours = Record<DayOfWeek, DailyOpeningHours>;
 
 export type ResponseSpeed = 'slow' | 'normal' | 'fast';
 
-export type IntegrationProvider = 'none' | 'garage_hive';
+export type IntegrationProvider = 'none' | 'garage_hive' | 'hubspot';
 
 export type AgentType = 'assist' | 'automate';
 
@@ -74,6 +74,21 @@ export const cloneTyresoftSettings = (settings?: TyresoftSettings | null): Tyres
   tsPassword: typeof settings?.tsPassword === 'string' ? settings.tsPassword : '',
   tsApiKey: typeof settings?.tsApiKey === 'string' ? settings.tsApiKey : '',
   tsDepotId: typeof settings?.tsDepotId === 'string' ? settings.tsDepotId : (settings?.tsDepotId != null ? String(settings.tsDepotId) : ''),
+});
+
+export type HubspotSettings = {
+  apiToken: string;
+  ownerId: string;
+};
+
+export const createDefaultHubspotSettings = (): HubspotSettings => ({
+  apiToken: '',
+  ownerId: '',
+});
+
+export const cloneHubspotSettings = (settings?: HubspotSettings | null): HubspotSettings => ({
+  apiToken: typeof settings?.apiToken === 'string' ? settings.apiToken : '',
+  ownerId: typeof settings?.ownerId === 'string' ? settings.ownerId : '',
 });
 
 export type GarageHiveSettings = {
@@ -136,6 +151,7 @@ export type AgentConfigurationPayload = {
   integrationProvider: IntegrationProvider;
   garageHiveSettings: GarageHiveSettings;
   tyresoftSettings?: TyresoftSettings;
+  hubspotSettings?: HubspotSettings;
   agentType: AgentType;
   agentScript?: 'receptionmate-agent' | 'receptionmate-agent-v3' | 'tyresoft-agent';
   enableSmsBookingLinks?: boolean;

--- a/backend/src/utils/validators.ts
+++ b/backend/src/utils/validators.ts
@@ -154,6 +154,13 @@ const tyresoftSettingsSchema = z
   })
   .optional();
 
+const hubspotSettingsSchema = z
+  .object({
+    apiToken: optionalBoundedString(4096),
+    ownerId: optionalBoundedString(100),
+  })
+  .optional();
+
 const timeString = z
   .string()
   .regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Use HH:MM in 24-hour time');
@@ -241,9 +248,10 @@ export const upsertAgentConfigurationSchema = z.object({
   dropOffMessage: z.string().max(500).optional(),
   dropOffExcludeServices: z.array(z.string().max(100)).max(20).optional(),
   notificationEmails: z.array(z.string().email().max(254)).max(10).optional(),
-  integrationProvider: z.enum(['none', 'garage_hive']).optional(),
+  integrationProvider: z.enum(['none', 'garage_hive', 'hubspot']).optional(),
   garageHiveSettings: garageHiveSettingsSchema,
   tyresoftSettings: tyresoftSettingsSchema,
+  hubspotSettings: hubspotSettingsSchema,
   agentType: z.enum(['assist', 'automate']).optional(),
   agentScript: z.enum(['receptionmate-agent', 'receptionmate-agent-v3', 'tyresoft-agent']).optional(),
   enableSmsBookingLinks: z.boolean().optional(),

--- a/backend/src/utils/validators.ts
+++ b/backend/src/utils/validators.ts
@@ -156,6 +156,7 @@ const tyresoftSettingsSchema = z
 
 const hubspotSettingsSchema = z
   .object({
+    enabled: z.boolean().optional(),
     apiToken: optionalBoundedString(4096),
     ownerId: optionalBoundedString(100),
   })
@@ -248,7 +249,7 @@ export const upsertAgentConfigurationSchema = z.object({
   dropOffMessage: z.string().max(500).optional(),
   dropOffExcludeServices: z.array(z.string().max(100)).max(20).optional(),
   notificationEmails: z.array(z.string().email().max(254)).max(10).optional(),
-  integrationProvider: z.enum(['none', 'garage_hive', 'hubspot']).optional(),
+  integrationProvider: z.enum(['none', 'garage_hive']).optional(),
   garageHiveSettings: garageHiveSettingsSchema,
   tyresoftSettings: tyresoftSettingsSchema,
   hubspotSettings: hubspotSettingsSchema,


### PR DESCRIPTION
## Summary

- Garages can now connect HubSpot so every inbound call creates a contact + inbox ticket, just like a form submission
- Each garage is isolated — HubSpot is opt-in per garage via Agent Config → System → HubSpot
- Step-by-step Private App setup instructions shown inline in the portal UI

## Changes

- `backend/src/services/hubspot.ts` — new service: contact upsert, inbox ticket, call engagement
- `backend/src/routes/calls.ts` — fires HubSpot after call is saved (non-blocking)
- `backend/src/routes/config.ts` — handles hubspot provider in parse/save/sanitize
- `backend/src/utils/types.ts` + `validators.ts` — `HubspotSettings` type, `'hubspot'` enum value
- `app/types/index.ts` + `app/agent-configurations/page.tsx` — HubSpot UI with inline setup guide

## Test plan

- [ ] Set a test garage to `integrationProvider = hubspot` with a valid Private App token
- [ ] Trigger a test call — verify contact created, ticket appears in HubSpot inbox, call logged on timeline
- [ ] Confirm other garages (GarageHive, email-only) are unaffected

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)