### PR TITLE
fix: Tyresoft config nested format + page reload on save

### DIFF
--- a/app/agent-configurations/page.tsx
+++ b/app/agent-configurations/page.tsx
@@ -249,11 +249,8 @@ export default function AgentConfigurationsPage() {
   const mutation = useMutation({
     mutationFn: (payload: AgentConfiguration) =>
       updateAgentConfiguration(payload, garageId ?? undefined),
-    onSuccess: (data) => {
-      setFormState(cloneConfiguration(data.configuration));
-      setKnowledgeBase(data.knowledgeBase ?? []);
-      setIsEditing(false);
-      setFeedback('Configuration saved and applied to your agent.');
+    onSuccess: () => {
+      window.location.reload();
     },
     onError: (error: unknown) => {
       const message =

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -98,7 +98,11 @@ const parseIntegrationSettings = (
   // Tyresoft agent takes priority — check agentScript first regardless of integrationProvider
   if (agentScript === 'tyresoft-agent') {
     if (rawSettings && typeof rawSettings === 'object' && !Array.isArray(rawSettings)) {
-      const raw = rawSettings as Record<string, unknown>;
+      // Support both flat {tsWorkspace: ...} and nested {tyresoft: {tsWorkspace: ...}} formats
+      const top = rawSettings as Record<string, unknown>;
+      const raw: Record<string, unknown> = (top.tyresoft && typeof top.tyresoft === 'object' && !Array.isArray(top.tyresoft))
+        ? top.tyresoft as Record<string, unknown>
+        : top;
       return {
         integrationProvider: 'none',
         garageHiveSettings: createDefaultGarageHiveSettings(),

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -654,13 +654,22 @@ router.put(
     const rawTyresoft = data.tyresoftSettings ?? {};
     // Tyresoft takes priority — if agentScript is tyresoft-agent and credentials provided, store them.
     // If credentials are not provided in this save, fall back to existing saved config to avoid wiping it.
+    // Normalize existing Tyresoft config — handle both flat and nested {tyresoft:{...}} formats
+    const existingRaw = existingConfig?.integrationProviderConfig;
+    const existingTyresoftFlat: object = (() => {
+      if (!existingRaw || typeof existingRaw !== 'object' || Array.isArray(existingRaw)) return {};
+      const top = existingRaw as Record<string, unknown>;
+      if (top.tyresoft && typeof top.tyresoft === 'object' && !Array.isArray(top.tyresoft)) {
+        return top.tyresoft as object;
+      }
+      return top;
+    })();
+
     const integrationProviderConfig: Prisma.InputJsonValue | null =
       resolvedAgentScript === 'tyresoft-agent' && rawTyresoft.tsWorkspace
         ? {
-            // Spread existing config first to preserve pricingRules, tsServices, tsChannelId etc.
-            ...(existingConfig?.integrationProviderConfig && typeof existingConfig.integrationProviderConfig === 'object' && !Array.isArray(existingConfig.integrationProviderConfig)
-              ? existingConfig.integrationProviderConfig as object
-              : {}),
+            // Spread normalized existing config to preserve pricingRules, tsServices, tsChannelId etc.
+            ...existingTyresoftFlat,
             tsWorkspace: typeof rawTyresoft.tsWorkspace === 'string' ? rawTyresoft.tsWorkspace.trim() : '',
             tsUsername: typeof rawTyresoft.tsUsername === 'string' ? rawTyresoft.tsUsername.trim() : '',
             tsPassword: typeof rawTyresoft.tsPassword === 'string' ? rawTyresoft.tsPassword.trim() : '',


### PR DESCRIPTION
## Summary
- Fixes config parser to handle nested \`{tyresoft:{...}}\` format (used by onboarding script) so credentials and pricing rules load correctly
- Normalizes to flat format on save to prevent mixed state after first UI save
- Page auto-reloads after Save Config so updated pricing rules immediately appear

Follows up on #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)