### PR TITLE
feat(hubspot): inbox email approach + inboxEmail field

### DIFF
--- a/app/agent-configurations/page.tsx
+++ b/app/agent-configurations/page.tsx
@@ -108,12 +108,14 @@ const createEmptyHubspotSettings = (): HubspotSettings => ({
   enabled: false,
   apiToken: '',
   ownerId: '',
+  inboxEmail: '',
 });
 
 const cloneHubspotSettings = (settings: HubspotSettings | undefined): HubspotSettings => ({
   enabled: settings?.enabled === true,
   apiToken: settings?.apiToken ?? '',
   ownerId: settings?.ownerId ?? '',
+  inboxEmail: settings?.inboxEmail ?? '',
 });
 
 const createEmptyConfiguration = (): AgentConfiguration => ({
@@ -2060,7 +2062,7 @@ export default function AgentConfigurationsPage() {
         <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/30">
           <h2 className="text-lg font-semibold text-slate-100">CRM Integration</h2>
           <p className="mt-1 text-sm text-slate-400">
-            Connect HubSpot so every inbound call automatically creates a contact and deal record.
+            Connect HubSpot so every inbound call automatically creates a contact and a conversation thread in your Conversations inbox.
           </p>
           <div className="mt-6 space-y-5">
             <label className="flex items-center gap-3 cursor-pointer">
@@ -2078,12 +2080,13 @@ export default function AgentConfigurationsPage() {
               isEditing ? (
                 <div className="flex flex-col gap-5">
                   <div className="rounded-xl border border-sky-800/40 bg-sky-950/30 p-4 text-sm text-slate-300">
-                    <p className="mb-3 font-medium text-sky-300">How to set up your HubSpot token</p>
+                    <p className="mb-3 font-medium text-sky-300">How to set up HubSpot integration</p>
                     <ol className="flex flex-col gap-2 text-slate-400 list-decimal list-inside">
                       <li>Log in to HubSpot → Settings (top-right gear icon).</li>
                       <li>Go to <span className="text-slate-200">Integrations → Legacy Apps</span> → create or open your app.</li>
-                      <li>Under Scopes, enable: <code className="text-sky-300">crm.objects.contacts.read</code>, <code className="text-sky-300">crm.objects.contacts.write</code>, <code className="text-sky-300">crm.objects.deals.write</code>.</li>
+                      <li>Under Scopes, enable: <code className="text-sky-300">crm.objects.contacts.read</code>, <code className="text-sky-300">crm.objects.contacts.write</code>, <code className="text-sky-300">crm.objects.calls.write</code>.</li>
                       <li>Copy the token (starts with <code className="text-sky-300">pat-</code>) and paste it below.</li>
+                      <li>To get your Inbox Email: go to <span className="text-slate-200">Conversations → Settings → Inboxes</span> → click your inbox → <span className="text-slate-200">Team email</span> tab → copy the address (e.g. <code className="text-sky-300">support@12345.hs-inbox.com</code>).</li>
                     </ol>
                   </div>
                   <div className="grid gap-5 md:grid-cols-2">
@@ -2098,6 +2101,18 @@ export default function AgentConfigurationsPage() {
                         className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
                       />
                     </label>
+                    <label className="flex flex-col gap-2 text-sm text-slate-300 md:col-span-2">
+                      <span className="text-xs uppercase tracking-wide text-slate-500">Inbox Email Address (optional)</span>
+                      <input
+                        type="email"
+                        placeholder="support@12345.hs-inbox.com"
+                        value={formState.hubspotSettings?.inboxEmail ?? ''}
+                        onChange={handleHubspotSettingsChange('inboxEmail')}
+                        disabled={!isEditing || mutation.isPending}
+                        className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                      />
+                      <span className="text-xs text-slate-500">When set, each call will also appear as a new message in your HubSpot Conversations inbox — just like a form submission.</span>
+                    </label>
                     <label className="flex flex-col gap-2 text-sm text-slate-300">
                       <span className="text-xs uppercase tracking-wide text-slate-500">HubSpot Owner ID (optional)</span>
                       <input
@@ -2108,7 +2123,7 @@ export default function AgentConfigurationsPage() {
                         disabled={!isEditing || mutation.isPending}
                         className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
                       />
-                      <span className="text-xs text-slate-500">Assign deals to a specific HubSpot user. Leave blank to log without an owner.</span>
+                      <span className="text-xs text-slate-500">Assign call records to a specific HubSpot user. Leave blank to log without an owner.</span>
                     </label>
                   </div>
                 </div>
@@ -2118,6 +2133,10 @@ export default function AgentConfigurationsPage() {
                     <div>
                       <span className="text-xs uppercase tracking-wide text-slate-500">Private App Token</span>
                       <div className="text-slate-100">{formState.hubspotSettings?.apiToken ? '••••••••••••••••' : 'Not set'}</div>
+                    </div>
+                    <div>
+                      <span className="text-xs uppercase tracking-wide text-slate-500">Inbox Email</span>
+                      <div className="text-slate-100">{formState.hubspotSettings?.inboxEmail || 'Not set'}</div>
                     </div>
                     <div>
                       <span className="text-xs uppercase tracking-wide text-slate-500">Owner ID</span>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -191,6 +191,7 @@ export interface HubspotSettings {
   enabled: boolean;
   apiToken: string;
   ownerId: string;
+  inboxEmail: string;
 }
 
 export interface AgentConfiguration {

--- a/backend/src/routes/calls.ts
+++ b/backend/src/routes/calls.ts
@@ -268,6 +268,7 @@ router.post('/calls', async (req: Request, res: Response) => {
           enabled: true,
           apiToken: rawHubspot.apiToken,
           ownerId: typeof rawHubspot.ownerId === 'string' ? rawHubspot.ownerId : '',
+          inboxEmail: typeof rawHubspot.inboxEmail === 'string' ? rawHubspot.inboxEmail : '',
         });
         void logCallToHubSpot({
           customerName: payload.customerName ?? null,

--- a/backend/src/services/hubspot.ts
+++ b/backend/src/services/hubspot.ts
@@ -1,4 +1,5 @@
 import type { HubspotSettings } from '../utils/types.js';
+import { sendEmail } from '../utils/email.js';
 
 const HUBSPOT_API_BASE = 'https://api.hubapi.com';
 
@@ -101,15 +102,11 @@ const createContact = async (call: HubSpotCallData, apiToken: string): Promise<s
 };
 
 /**
- * Creates a HubSpot ticket (appears in inbox, like a form submission).
- * Associates it with the contact if contactId is provided.
+ * Sends an email to the HubSpot inbox email address.
+ * HubSpot converts any inbound email to the inbox address into a conversation
+ * thread in the Main Inbox — exactly like a form submission.
  */
-const createTicket = async (
-  call: HubSpotCallData,
-  contactId: string | null,
-  ownerId: string,
-  apiToken: string,
-): Promise<string | null> => {
+const sendInboxEmail = async (call: HubSpotCallData, inboxEmail: string): Promise<void> => {
   const phone = call.customerPhone || call.fromNumber || 'Unknown';
   const subject = call.confirmedBooking
     ? `Booking confirmed — ${call.customerName || phone} (${call.branchName})`
@@ -121,44 +118,26 @@ const createTicket = async (
   if (call.customerName) lines.push(`Name: ${call.customerName}`);
   if (call.registrationNumber) lines.push(`Vehicle Registration: ${call.registrationNumber}`);
   lines.push(`Call Type: ${call.callType || 'Unknown'}`);
-  lines.push(`Duration: ${Math.round(call.durationSeconds / 60)}m ${call.durationSeconds % 60}s`);
+  const mins = Math.floor(call.durationSeconds / 60);
+  const secs = call.durationSeconds % 60;
+  lines.push(`Duration: ${mins}m ${secs}s`);
   if (call.confirmedBooking) lines.push(`Booking Confirmed: Yes`);
   if (call.bookingDetails) lines.push(`\nBooking Details:\n${call.bookingDetails}`);
   if (call.summary) lines.push(`\nCall Summary:\n${call.summary}`);
+  const text = lines.join('\n');
 
-  const properties: Record<string, string> = {
+  const sent = await sendEmail({
+    to: [inboxEmail],
     subject,
-    content: lines.join('\n'),
-    hs_ticket_priority: call.confirmedBooking ? 'HIGH' : 'MEDIUM',
-    hs_pipeline: '0',        // default support pipeline
-    hs_pipeline_stage: '1',  // New
-  };
-
-  if (ownerId) properties.hubspot_owner_id = ownerId;
-
-  const associations = contactId
-    ? [
-        {
-          to: { id: contactId },
-          types: [{ associationCategory: 'HUBSPOT_DEFINED', associationTypeId: 16 }], // Ticket → Contact
-        },
-      ]
-    : undefined;
-
-  const response = await hubspotFetch('/crm/v3/objects/tickets', apiToken, {
-    method: 'POST',
-    body: JSON.stringify({ properties, ...(associations ? { associations } : {}) }),
+    text,
+    html: `<pre style="font-family:sans-serif;white-space:pre-wrap">${text}</pre>`,
   });
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => '');
-    console.error(`[HUBSPOT] Failed to create ticket: ${response.status} ${text}`);
-    return null;
+  if (sent) {
+    console.log(`[HUBSPOT] Inbox email sent to ${inboxEmail} for call from ${phone}`);
+  } else {
+    console.warn(`[HUBSPOT] Failed to send inbox email to ${inboxEmail}`);
   }
-
-  const result = await response.json() as { id: string };
-  console.log(`[HUBSPOT] Ticket created: ${result.id}`);
-  return result.id;
 };
 
 /**
@@ -209,19 +188,18 @@ const logCallEngagement = async (
 };
 
 /**
- * Main entry point: upserts a contact, creates an inbox ticket, and logs a call engagement.
+ * Main entry point: upserts a contact, sends an inbox email thread, and logs a call engagement.
  *
  * Required Private App scopes:
  *   crm.objects.contacts.read
  *   crm.objects.contacts.write
- *   crm.objects.tickets.write
  *   crm.objects.calls.write
  */
 export const logCallToHubSpot = async (
   call: HubSpotCallData,
   settings: HubspotSettings,
 ): Promise<void> => {
-  const { apiToken, ownerId } = settings;
+  const { apiToken, ownerId, inboxEmail } = settings;
   if (!apiToken) {
     console.error('[HUBSPOT] No API token configured — skipping');
     return;
@@ -241,8 +219,10 @@ export const logCallToHubSpot = async (
     }
   }
 
-  // 2. Create inbox ticket (visible in HubSpot inbox, like a form submission)
-  await createTicket(call, contactId, ownerId, apiToken);
+  // 2. Send inbox email (appears in HubSpot Conversations Main Inbox like a form submission)
+  if (inboxEmail) {
+    await sendInboxEmail(call, inboxEmail);
+  }
 
   // 3. Log call engagement on the contact timeline
   await logCallEngagement(call, contactId, ownerId, apiToken);

--- a/backend/src/utils/types.ts
+++ b/backend/src/utils/types.ts
@@ -120,18 +120,21 @@ export type HubspotSettings = {
   enabled: boolean;
   apiToken: string;
   ownerId: string;
+  inboxEmail: string;
 };
 
 export const createDefaultHubspotSettings = (): HubspotSettings => ({
   enabled: false,
   apiToken: '',
   ownerId: '',
+  inboxEmail: '',
 });
 
 export const cloneHubspotSettings = (settings?: HubspotSettings | null): HubspotSettings => ({
   enabled: settings?.enabled === true,
   apiToken: typeof settings?.apiToken === 'string' ? settings.apiToken : '',
   ownerId: typeof settings?.ownerId === 'string' ? settings.ownerId : '',
+  inboxEmail: typeof settings?.inboxEmail === 'string' ? settings.inboxEmail : '',
 });
 
 export type AgentConfigurationPayload = {

--- a/backend/src/utils/validators.ts
+++ b/backend/src/utils/validators.ts
@@ -255,6 +255,7 @@ export const upsertAgentConfigurationSchema = z.object({
     enabled: z.boolean(),
     apiToken: z.string(),
     ownerId: z.string(),
+    inboxEmail: z.string().optional().default(''),
   }).optional(),
 }).superRefine((value, ctx) => {
   const provider = value.integrationProvider ?? 'none';


### PR DESCRIPTION
## Summary

- Replaces the broken `POST /conversations/v3/conversations/threads` approach (HubSpot returns 405 for all Private Apps — thread creation via API is blocked)
- Sends an email to the garage's HubSpot inbox address instead — HubSpot converts any inbound email to `support@{portalId}.hs-inbox.com` into a conversation thread in Main Inbox, exactly like a form submission
- Adds `inboxEmail` field to `HubspotSettings` (optional — if blank, inbox threading is skipped but CRM contact + call timeline still works)
- Simplifies required Private App scopes: `crm.objects.contacts.read`, `crm.objects.contacts.write`, `crm.objects.calls.write` (no longer need `conversations.read/write`)

## What works after this PR

1. **CRM contact** — caller is found or created by phone number ✅ (already tested)
2. **Call timeline** — call engagement logged on contact record ✅ (already tested)
3. **Inbox thread** — fires if `inboxEmail` is configured in portal settings (Ash needs to find her inbox email in HubSpot → Conversations → Settings → Inboxes)

## Test plan

- [ ] Deploy to production (compile backend + PM2 restart)
- [ ] Regal Autosport: create Private App with 3 scopes, paste token in portal
- [ ] Regal: find inbox email in HubSpot Conversations settings, paste in portal
- [ ] Trigger a test call — verify contact created + call on timeline + inbox thread appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)