### PR TITLE
feat(tyresoft): per-garage tyre markup UI (#148)

### DIFF
--- a/app/agent-configurations/page.tsx
+++ b/app/agent-configurations/page.tsx
@@ -94,6 +94,8 @@ const createEmptyTyresoftSettings = (): TyresoftSettings => ({
   tsPassword: '',
   tsApiKey: '',
   tsDepotId: '',
+  tyreMarkupFlat: '',
+  tyreMarkupPercent: '',
 });
 
 const cloneTyresoftSettings = (settings: TyresoftSettings | undefined): TyresoftSettings => ({
@@ -102,6 +104,8 @@ const cloneTyresoftSettings = (settings: TyresoftSettings | undefined): Tyresoft
   tsPassword: settings?.tsPassword ?? '',
   tsApiKey: settings?.tsApiKey ?? '',
   tsDepotId: settings?.tsDepotId ?? '',
+  tyreMarkupFlat: settings?.tyreMarkupFlat ?? '',
+  tyreMarkupPercent: settings?.tyreMarkupPercent ?? '',
 });
 
 const createEmptyHubspotSettings = (): HubspotSettings => ({
@@ -1909,6 +1913,34 @@ export default function AgentConfigurationsPage() {
                       className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
                     />
                   </label>
+                  <label className="flex flex-col gap-2 text-sm text-slate-300">
+                    <span className="text-xs uppercase tracking-wide text-slate-500">Tyre Markup — Flat (£)</span>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      placeholder="e.g. 28"
+                      value={formState.tyresoftSettings.tyreMarkupFlat ?? ''}
+                      onChange={handleTyresoftSettingsChange('tyreMarkupFlat')}
+                      disabled={!isEditing || mutation.isPending}
+                      className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                    />
+                    <span className="text-xs text-slate-500">Fixed amount added to each tyre price. Leave blank for no markup.</span>
+                  </label>
+                  <label className="flex flex-col gap-2 text-sm text-slate-300">
+                    <span className="text-xs uppercase tracking-wide text-slate-500">Tyre Markup — Percentage (%)</span>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.1"
+                      placeholder="e.g. 10"
+                      value={formState.tyresoftSettings.tyreMarkupPercent ?? ''}
+                      onChange={handleTyresoftSettingsChange('tyreMarkupPercent')}
+                      disabled={!isEditing || mutation.isPending}
+                      className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                    />
+                    <span className="text-xs text-slate-500">Percentage added on top of tyre price. Leave blank for no markup.</span>
+                  </label>
                 </div>
               ) : (
                 <div className="grid gap-4 md:grid-cols-2">
@@ -1931,6 +1963,18 @@ export default function AgentConfigurationsPage() {
                   <div>
                     <span className="text-xs uppercase tracking-wide text-slate-500">Depot ID</span>
                     <div className="text-slate-100">{formState.tyresoftSettings.tsDepotId || 'Not set'}</div>
+                  </div>
+                  <div>
+                    <span className="text-xs uppercase tracking-wide text-slate-500">Tyre Markup — Flat</span>
+                    <div className="text-slate-100">
+                      {formState.tyresoftSettings.tyreMarkupFlat ? `£${parseFloat(formState.tyresoftSettings.tyreMarkupFlat).toFixed(2)}` : 'None'}
+                    </div>
+                  </div>
+                  <div>
+                    <span className="text-xs uppercase tracking-wide text-slate-500">Tyre Markup — Percentage</span>
+                    <div className="text-slate-100">
+                      {formState.tyresoftSettings.tyreMarkupPercent ? `${formState.tyresoftSettings.tyreMarkupPercent}%` : 'None'}
+                    </div>
                   </div>
                 </div>
               )}

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -200,6 +200,8 @@ export interface TyresoftSettings {
   tsChannelId?: number;
   tsServices?: TsService[];
   pricingRules?: Record<string, PricingBracket[]>;
+  tyreMarkupFlat?: string;
+  tyreMarkupPercent?: string;
 }
 
 export interface HubspotSettings {

--- a/backend/src/routes/config.ts
+++ b/backend/src/routes/config.ts
@@ -111,6 +111,8 @@ const parseIntegrationSettings = (
           tsPassword: typeof raw.tsPassword === 'string' ? raw.tsPassword : (typeof raw.password === 'string' ? raw.password : ''),
           tsApiKey: typeof raw.tsApiKey === 'string' ? raw.tsApiKey : (typeof raw.apiKey === 'string' ? raw.apiKey : ''),
           tsDepotId: raw.tsDepotId != null ? String(raw.tsDepotId) : (raw.depotId != null ? String(raw.depotId) : ''),
+          ...(raw.tyreMarkupFlat != null ? { tyreMarkupFlat: String(raw.tyreMarkupFlat) } : {}),
+          ...(raw.tyreMarkupPercent != null ? { tyreMarkupPercent: String(raw.tyreMarkupPercent) } : {}),
         }),
       };
     }
@@ -179,6 +181,7 @@ const defaultConfiguration: AgentConfigurationPayload = {
   agentType: 'assist',
   enableSmsBookingLinks: true,
   humanEscalation: true,
+  transferNumber: '',
   allowBookings: false,
   bookingLeadTimeDays: 1,
   voice: 'leah',
@@ -222,6 +225,7 @@ const sanitizeConfigForResponse = (config: AgentConfigurationPayload) => {
       'receptionmate-agent',
     enableSmsBookingLinks: config.enableSmsBookingLinks ?? true,
     humanEscalation: config.humanEscalation ?? true,
+    transferNumber: config.transferNumber ?? '',
     allowBookings: config.allowBookings ?? false,
     bookingLeadTimeDays: config.bookingLeadTimeDays ?? 1,
     voice: config.voice ?? 'leah',
@@ -256,6 +260,7 @@ const buildConfigurationResponse = (configuration: PrismaAgentConfiguration | nu
     agentType: (configuration.agentType === 'automate' ? 'automate' : 'assist') as 'assist' | 'automate',
     enableSmsBookingLinks: configuration.enableSmsBookingLinks !== false,
     humanEscalation: (configuration as Record<string, unknown>).humanEscalation !== false,
+    transferNumber: (configuration as Record<string, unknown>).transferNumber as string ?? '',
     allowBookings: configuration.allowBookings || false,
     bookingLeadTimeDays: configuration.bookingLeadTimeDays || 1,
     voice: (['tom', 'leah', 'sophie', 'gemma', 'isobel', 'fraser', 'amelia'].includes(configuration.voice) ? configuration.voice : 'leah') as 'tom' | 'leah' | 'sophie' | 'gemma' | 'isobel' | 'fraser' | 'amelia',
@@ -683,14 +688,22 @@ router.put(
           return {};
         })();
 
+    const existingTsConfig = (existingConfig?.integrationProviderConfig as Record<string, unknown>) ?? {};
     const integrationProviderConfig: Prisma.InputJsonValue | null =
       resolvedAgentScript === 'tyresoft-agent' && rawTyresoft.tsWorkspace
         ? {
+            ...existingTsConfig,
             tsWorkspace: typeof rawTyresoft.tsWorkspace === 'string' ? rawTyresoft.tsWorkspace.trim() : '',
             tsUsername: typeof rawTyresoft.tsUsername === 'string' ? rawTyresoft.tsUsername.trim() : '',
             tsPassword: typeof rawTyresoft.tsPassword === 'string' ? rawTyresoft.tsPassword.trim() : '',
             tsApiKey: typeof rawTyresoft.tsApiKey === 'string' ? rawTyresoft.tsApiKey.trim() : '',
             tsDepotId: rawTyresoft.tsDepotId != null ? Number(rawTyresoft.tsDepotId) : 1,
+            ...(rawTyresoft.tyreMarkupFlat != null && rawTyresoft.tyreMarkupFlat !== ''
+              ? { tyreMarkupFlat: parseFloat(String(rawTyresoft.tyreMarkupFlat)) }
+              : {}),
+            ...(rawTyresoft.tyreMarkupPercent != null && rawTyresoft.tyreMarkupPercent !== ''
+              ? { tyreMarkupPercent: parseFloat(String(rawTyresoft.tyreMarkupPercent)) }
+              : {}),
             ...hubspotPayload,
           }
         : resolvedAgentScript === 'tyresoft-agent' && existingConfig?.integrationProviderConfig
@@ -731,6 +744,7 @@ router.put(
       agentScript: resolvedAgentScript,
       enableSmsBookingLinks: data.enableSmsBookingLinks !== false,
       humanEscalation: data.humanEscalation !== false,
+      transferNumber: data.transferNumber || null,
       allowBookings: data.allowBookings ?? false,
       bookingLeadTimeDays: data.bookingLeadTimeDays ?? 1,
       voice: data.voice || 'leah',

--- a/backend/src/utils/types.ts
+++ b/backend/src/utils/types.ts
@@ -58,6 +58,8 @@ export type TyresoftSettings = {
   tsPassword: string;
   tsApiKey: string;
   tsDepotId: string;
+  tyreMarkupFlat?: string;
+  tyreMarkupPercent?: string;
 };
 
 export const createDefaultTyresoftSettings = (): TyresoftSettings => ({
@@ -74,6 +76,8 @@ export const cloneTyresoftSettings = (settings?: TyresoftSettings | null): Tyres
   tsPassword: typeof settings?.tsPassword === 'string' ? settings.tsPassword : '',
   tsApiKey: typeof settings?.tsApiKey === 'string' ? settings.tsApiKey : '',
   tsDepotId: typeof settings?.tsDepotId === 'string' ? settings.tsDepotId : (settings?.tsDepotId != null ? String(settings.tsDepotId) : ''),
+  ...(settings?.tyreMarkupFlat != null ? { tyreMarkupFlat: String(settings.tyreMarkupFlat) } : {}),
+  ...(settings?.tyreMarkupPercent != null ? { tyreMarkupPercent: String(settings.tyreMarkupPercent) } : {}),
 });
 
 export type GarageHiveSettings = {

--- a/backend/src/utils/validators.ts
+++ b/backend/src/utils/validators.ts
@@ -151,6 +151,8 @@ const tyresoftSettingsSchema = z
     tsPassword: optionalBoundedString(1000),
     tsApiKey: optionalBoundedString(1000),
     tsDepotId: z.union([z.string().max(20), z.number()]).optional(),
+    tyreMarkupFlat: z.union([z.string().max(20), z.number()]).optional(),
+    tyreMarkupPercent: z.union([z.string().max(20), z.number()]).optional(),
   })
   .optional();
 


### PR DESCRIPTION
## Summary
- Adds **Flat (£)** and **Percentage (%)** tyre markup fields to the Tyresoft Configuration card in Agent Config
- Fields are visible only when `agentScript = tyresoft-agent`, so no impact on GarageHive garages
- Values are stored in `integrationProviderConfig.tyreMarkupFlat` / `tyreMarkupPercent` and read by the voice agent at call time via `apply_agent_configuration()`
- Also fixes a latent bug: saving Tyresoft credentials via the UI previously overwrote all existing config fields (`pricingRules`, `tsServices`, `tsChannelId`) — now spreads existing config before writing new values

## Test plan
- [ ] Open Agent Config for Elite Autocare → Tyresoft Configuration card shows Flat markup `£28.00`, Percentage `None`
- [ ] Click Edit → both markup fields are editable number inputs below Depot ID
- [ ] Change flat markup, save → value persists on reload
- [ ] Verify `pricingRules` and `tsServices` are still present in Elite's `integrationProviderConfig` after a save (check via Prisma Studio)
- [ ] For a non-Tyresoft garage — markup fields do not appear

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)