### PR TITLE
fix(security): low+medium audit fixes

### DIFF
--- a/app/api/widget/[garageId]/route.ts
+++ b/app/api/widget/[garageId]/route.ts
@@ -8,7 +8,10 @@ export async function GET(
     const { garageId } = await params;
     
     // Use backend API URL - works for both local dev and production
-    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL || 'http://18.171.230.217:4000';
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!backendUrl) {
+      return NextResponse.json({ error: 'Backend URL not configured' }, { status: 500 });
+    }
     const response = await fetch(
       `${backendUrl}/api/widget/${garageId}`,
       { 

--- a/app/widget/[garageId]/page.tsx
+++ b/app/widget/[garageId]/page.tsx
@@ -213,7 +213,8 @@ export default function ChatWidget() {
     setSending(true);
 
     try {
-      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL || 'http://18.171.230.217:4000';
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
+      if (!backendUrl) throw new Error('Backend URL not configured');
       const response = await fetch(`${backendUrl}/api/chat/widget`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -279,7 +280,8 @@ export default function ChatWidget() {
 
     try {
       // Use production backend
-      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL || 'http://18.171.230.217:4000';
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
+      if (!backendUrl) throw new Error('Backend URL not configured');
       const response = await fetch(`${backendUrl}/api/chat/widget`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/backend/src/routes/admin-fb-connection.ts
+++ b/backend/src/routes/admin-fb-connection.ts
@@ -1,73 +1,15 @@
 import { Router } from 'express';
-import { prisma } from '../db.js';
+import { authenticate } from '../middleware/auth.js';
 
 const router = Router();
 
-router.post('/admin/create-fb-connection', async (req, res) => {
-  try {
-    const garageId = 'd51dfa55-15d0-4d60-ad81-c675579d16f6';
-    const pageId = '224576834077659';
-    const accessToken = 'EAAWvZApHZBPUwBQjJTmTJ25OYfKab5xQMI1Bt6EntSYPtRqBET2HG5CB0KHONmmrbyOgAClLVi9shkGhKn0BcRZCiAyVasbfhpTZA4IShK3pZAJDJiUJDbfhMy2MsX40rIycYpqa3I1WzKOuT5TjyqTy0DBAESZACuw65pTqpbvwtZB0m7pjDJ5NsuVg6jNkMZBkfW9p';
-
-    console.log('=== Creating Facebook Connection ===');
-    console.log('Target Garage ID:', garageId);
-    console.log('Page ID:', pageId);
-
-    // First, delete all existing Facebook connections
-    const deleted = await prisma.socialMediaConnection.deleteMany({
-      where: { platform: 'facebook' },
-    });
-    console.log(`Deleted ${deleted.count} old Facebook connection(s)`);
-
-    // Create new connection in correct garage
-    const connection = await prisma.socialMediaConnection.create({
-      data: {
-        garageId,
-        platform: 'facebook',
-        pageId,
-        accessToken,
-        isActive: true,
-      },
-    });
-
-    console.log('✅ Facebook connection created successfully!');
-    console.log('Connection ID:', connection.id);
-
-    // Verify the garage has GarageHive configured
-    const garage = await prisma.garage.findUnique({
-      where: { id: garageId },
-      include: { agentConfiguration: true },
-    });
-
-    const hasGH = garage?.agentConfiguration?.integrationProvider === 'garagehive' ||
-                  (garage?.agentConfiguration?.integrationProviderConfig &&
-                   (garage.agentConfiguration.integrationProviderConfig as any).ghCustomerId);
-
-    console.log('GarageHive configured?', hasGH);
-
-    res.json({
-      success: true,
-      connection: {
-        id: connection.id,
-        garageId: connection.garageId,
-        pageId: connection.pageId,
-        platform: connection.platform,
-        isActive: connection.isActive,
-      },
-      garage: {
-        name: garage?.name,
-        hasGarageHive: hasGH,
-      },
-      deletedCount: deleted.count,
-    });
-  } catch (error: any) {
-    console.error('❌ Error creating Facebook connection:', error);
-    res.status(500).json({
-      success: false,
-      error: error.message,
-      stack: error.stack,
-    });
-  }
+// This endpoint has been disabled.
+// It previously contained hardcoded credentials and no authentication.
+// Facebook connections should be managed via the OAuth flow in /api/oauth/meta/initiate.
+router.post('/admin/create-fb-connection', authenticate, (_req, res) => {
+  res.status(410).json({
+    error: 'This endpoint has been disabled. Use the OAuth integration flow instead.',
+  });
 });
 
 export default router;

--- a/backend/src/routes/calls.ts
+++ b/backend/src/routes/calls.ts
@@ -124,7 +124,8 @@ const parseCallJson = (call: Call & { feedback?: CallFeedback | null }): CallWit
 const ensureWebhookSecret = (req: Request) => {
   const configuredSecret = process.env.WEBHOOK_SECRET;
   if (!configuredSecret) {
-    return true;
+    console.error('[CALLS] WEBHOOK_SECRET is not configured — rejecting request');
+    return false;
   }
   const headerSecret =
     req.headers['x-webhook-secret'] ??

--- a/backend/src/routes/featureAnnouncement.ts
+++ b/backend/src/routes/featureAnnouncement.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { sendEmail } from '../utils/email.js';
 import { PrismaClient } from '@prisma/client';
+import { authenticate } from '../middleware/auth.js';
 
 const router = Router();
 const prisma = new PrismaClient();
@@ -199,8 +200,13 @@ Support: support@receptionmate.co.uk
 `;
 };
 
-router.post('/send-feature-announcement', async (req: Request, res: Response) => {
+router.post('/send-feature-announcement', authenticate, async (req: Request, res: Response) => {
   try {
+    // Only RECEPTIONMATE_STAFF can send announcements
+    if (req.user?.role !== 'RECEPTIONMATE_STAFF') {
+      return res.status(403).json({ error: 'Staff access required' });
+    }
+
     const { testEmail, sendToAll }: FeatureAnnouncementRequest = req.body;
 
     if (!testEmail && !sendToAll) {

--- a/backend/src/routes/onboarding.ts
+++ b/backend/src/routes/onboarding.ts
@@ -37,8 +37,11 @@ async function purchaseRandomTwilioNumber(): Promise<string> {
     console.log('[ONBOARDING] Auto-purchasing number:', selectedNumber);
 
     // Purchase the number with regulatory bundle
-    const bundleSid = 'BU08d2714daf3a61874f914319204d51ca';
-    const addressSid = 'AD5d175e286a33f9348f9b19aa4bdd513a';
+    const bundleSid = process.env.TWILIO_BUNDLE_SID;
+    const addressSid = process.env.TWILIO_ADDRESS_SID;
+    if (!bundleSid || !addressSid) {
+      throw new Error('TWILIO_BUNDLE_SID and TWILIO_ADDRESS_SID must be configured');
+    }
 
     const purchasedNumber = await client.incomingPhoneNumbers.create({
       phoneNumber: selectedNumber,

--- a/backend/src/routes/twilio.ts
+++ b/backend/src/routes/twilio.ts
@@ -105,8 +105,11 @@ router.post('/admin/twilio/purchase', authenticateApiKey, requireAdmin, async (r
     }
 
     // Use the specific Local bundle and associated address
-    const bundleSid = 'BU08d2714daf3a61874f914319204d51ca';
-    const addressSid = 'AD5d175e286a33f9348f9b19aa4bdd513a';
+    const bundleSid = process.env.TWILIO_BUNDLE_SID;
+    const addressSid = process.env.TWILIO_ADDRESS_SID;
+    if (!bundleSid || !addressSid) {
+      return res.status(500).json({ error: 'TWILIO_BUNDLE_SID and TWILIO_ADDRESS_SID must be configured' });
+    }
 
     console.log(`Using Local bundle: ${bundleSid} with address: ${addressSid}`);
     console.log('Attempting to purchase:', phoneNumber);


### PR DESCRIPTION
## Summary
- Remove hardcoded Twilio bundle/address SIDs → env vars (`onboarding.ts`, `twilio.ts`)
- Remove hardcoded production IP `18.171.230.217:4000` fallback from widget (`route.ts`, `page.tsx`)
- Gut `admin-fb-connection` endpoint — had hardcoded access token + garageId with no auth, now returns 410
- Add `authenticate` middleware + `RECEPTIONMATE_STAFF` role check to feature announcement endpoint
- Reject webhook requests when `WEBHOOK_SECRET` is not configured instead of allowing all (`calls.ts`)

All changes are defensive — no business logic changes. Closes the easiest wins from security audit (Issue #200).

## Env vars needed on production
Before deploying, ensure these are set in `backend/.env`:
```
TWILIO_BUNDLE_SID=BU08d2714daf3a61874f914319204d51ca
TWILIO_ADDRESS_SID=AD5d175e286a33f9348f9b19aa4bdd513a
```
(These are the same values that were previously hardcoded.)

## Test plan
- [ ] Verify `TWILIO_BUNDLE_SID` and `TWILIO_ADDRESS_SID` are set in production `.env`
- [ ] Confirm widget chat still works (no hardcoded IP fallback needed since env vars are set)
- [ ] Confirm `POST /admin/create-fb-connection` returns 410
- [ ] Confirm feature announcements require staff login
- [ ] Confirm call webhooks still work (WEBHOOK_SECRET is already configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)