### PR TITLE
fix: preserve CONFIRMED step in handleTakeMessage (issue #221)

### DIFF
--- a/backend/src/services/chatAgentV2.ts
+++ b/backend/src/services/chatAgentV2.ts
@@ -1931,7 +1931,11 @@ async function handleTakeMessage(args: any, session: ChatSession, conversationId
   session.message = message;
   session.contactPhone = phone;
   session.preferredCallbackTime = callback_time;
-  session.step = Step.MESSAGE_ONLY;
+  // Don't overwrite CONFIRMED step — a post-booking take_message is a cancellation note,
+  // not a message-only session. Downgrading CONFIRMED → MESSAGE_ONLY loses booking context.
+  if (session.step !== Step.CONFIRMED) {
+    session.step = Step.MESSAGE_ONLY;
+  }
   await saveSession(conversationId, session);
 
   // Flag conversation as needing attention so it shows up in the Messages inbox


### PR DESCRIPTION
## Summary

**Issue:** In `handleTakeMessage` (~line 1934), `take_message` always unconditionally set `session.step = Step.MESSAGE_ONLY`, even when the session was already `CONFIRMED`. This caused post-booking cancellation notes to wipe the booking confirmation state, so on reload the agent had no memory of the confirmed booking.

**Fix:** Guard the step assignment with `if (session.step !== Step.CONFIRMED)` so that confirmed bookings are not downgraded to `MESSAGE_ONLY`.

## Changes

`backend/src/services/chatAgentV2.ts`:



Fixes danny901233/portal-frontend#221