### PR TITLE
fix(security): OAuth state signing + garage isolation on social connections

### DIFF
--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -1,10 +1,33 @@
 import type { Request, Response } from 'express';
 import { Router } from 'express';
+import { createHmac } from 'node:crypto';
 import axios from 'axios';
 import { prisma } from '../db.js';
 import { authenticate } from '../middleware/auth.js';
 
 const router = Router();
+
+const OAUTH_STATE_MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
+
+function signOAuthState(payload: Record<string, unknown>): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error('JWT_SECRET is not configured');
+  const withTimestamp = { ...payload, ts: Date.now() };
+  const data = JSON.stringify(withTimestamp);
+  const sig = createHmac('sha256', secret).update(data).digest('hex');
+  return Buffer.from(JSON.stringify({ d: withTimestamp, s: sig })).toString('base64');
+}
+
+function verifyOAuthState(state: string): Record<string, unknown> {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error('JWT_SECRET is not configured');
+  const parsed = JSON.parse(Buffer.from(state, 'base64').toString());
+  const { d, s } = parsed;
+  const expected = createHmac('sha256', secret).update(JSON.stringify(d)).digest('hex');
+  if (s !== expected) throw new Error('Invalid OAuth state signature');
+  if (Date.now() - d.ts > OAUTH_STATE_MAX_AGE_MS) throw new Error('OAuth state expired');
+  return d;
+}
 
 const META_APP_ID = process.env.META_APP_ID;
 const META_APP_SECRET = process.env.META_APP_SECRET;
@@ -38,8 +61,8 @@ router.post('/oauth/meta/initiate', authenticate, async (req: Request, res: Resp
       return res.status(400).json({ error: 'Invalid platform' });
     }
 
-    // Store state to verify callback
-    const state = Buffer.from(JSON.stringify({ garageId, platform })).toString('base64');
+    // Store state to verify callback — signed to prevent forgery
+    const state = signOAuthState({ garageId, platform });
 
     // All platforms use facebook.com OAuth dialog (Instagram connects via Facebook Page)
     const authUrl = new URL('https://www.facebook.com/v18.0/dialog/oauth');
@@ -71,8 +94,8 @@ router.get('/oauth/meta/callback', async (req: Request, res: Response) => {
       return res.redirect(`${process.env.FRONTEND_URL || 'http://localhost:3000'}/integrations?error=missing_params`);
     }
 
-    // Decode state
-    const { garageId, platform } = JSON.parse(Buffer.from(state as string, 'base64').toString());
+    // Verify and decode state — rejects tampered or expired states
+    const { garageId, platform } = verifyOAuthState(state as string) as { garageId: string; platform: string };
 
     // Exchange code for access token — Instagram Business Login uses a different endpoint
     let accessToken: string;

--- a/backend/src/routes/social-connections.ts
+++ b/backend/src/routes/social-connections.ts
@@ -2,8 +2,16 @@ import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { prisma } from '../db.js';
 import { authenticate } from '../middleware/auth.js';
+import { resolveAllowedGarages } from '../utils/auth.js';
 
 const router = Router();
+
+function hasGarageAccess(req: Request, garageId: string): boolean {
+  if (!req.user) return false;
+  const isStaff = req.user.role === 'RECEPTIONMATE_STAFF';
+  if (isStaff) return true;
+  return resolveAllowedGarages(req.user).includes(garageId);
+}
 
 // GET /api/garages/:garageId/social-connections - List all connections for a garage
 router.get(
@@ -12,6 +20,10 @@ router.get(
   async (req: Request, res: Response) => {
     try {
       const { garageId } = req.params;
+
+      if (!hasGarageAccess(req, garageId)) {
+        return res.status(403).json({ error: 'Access denied' });
+      }
 
       const connections = await prisma.socialMediaConnection.findMany({
         where: { garageId },
@@ -33,6 +45,19 @@ router.delete(
   async (req: Request, res: Response) => {
     try {
       const { connectionId } = req.params;
+
+      const connection = await prisma.socialMediaConnection.findUnique({
+        where: { id: connectionId },
+        select: { garageId: true },
+      });
+
+      if (!connection) {
+        return res.status(404).json({ error: 'Connection not found' });
+      }
+
+      if (!hasGarageAccess(req, connection.garageId)) {
+        return res.status(403).json({ error: 'Access denied' });
+      }
 
       await prisma.socialMediaConnection.delete({
         where: { id: connectionId },


### PR DESCRIPTION
## Summary

Two security fixes from the low/medium audit.

- **OAuth state forgery** — the OAuth callback state was plain base64, meaning anyone could decode it, change the `garageId`, re-encode it, and hijack the callback to link a Meta account to a garage they don't own. Now signed with HMAC-SHA256 using `JWT_SECRET` with a 10-minute expiry. Tampered or expired states are rejected with a 400.

- **Social connections garage isolation** — `GET /api/garages/:garageId/social-connections` and `DELETE /api/social-connections/:connectionId` only checked that the user was authenticated, not that the garage belonged to them. A logged-in user from Garage A could read or delete Garage B's connections. Both endpoints now verify garage ownership before proceeding.

## Test plan

- [ ] Connect a Meta platform (WhatsApp/Facebook/Instagram) via OAuth — confirm it still works end-to-end
- [ ] Attempt to tamper the `state` param in the callback URL — confirm it returns an error
- [ ] As a garage user, confirm you can view and delete your own social connections
- [ ] As a garage user, attempt to access another garage's connections — confirm 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)