### PR TITLE
HighLevel: trial signup → Free trial live → Live on conversion

### DIFF
--- a/backend/src/routes/public-signup.ts
+++ b/backend/src/routes/public-signup.ts
@@ -245,17 +245,26 @@ router.post('/public-signup', async (req: Request, res: Response) => {
       console.error('[PUBLIC_SIGNUP] sign-agreement email failed:', error);
     });
 
-    // 6. Fire-and-forget HighLevel push — contact + opportunity in the
-    //    "Onboarding Newest" pipeline so the team can track new accounts.
+    // 6. HighLevel push — contact + opportunity in the "Free trial live" stage of
+    //    the "Onboarding Newest" pipeline. Store the opportunity id so the Stripe
+    //    webhook can promote it to "Live and £££" when the 14-day trial converts.
     void pushSignupToHighlevel({
       name: name || businessName,
       email: normalizedEmail,
+      phone: phoneNumber ?? undefined,
       companyName: businessName,
+      website: websiteUrl ?? undefined,
       source: 'website-getstarted-assist',
-      tags: ['website-signup', 'assist'],
-      opportunityName: `${businessName} — Assist signup`,
+      tags: ['website-signup', 'assist', 'trial'],
+      opportunityName: `${businessName} — Assist 14-day trial (£${ASSIST_DEFAULTS.subscriptionCostGbp}/mo per branch)`,
       monetaryValueGbp: ASSIST_DEFAULTS.subscriptionCostGbp,
-      kind: 'signup',
+      kind: 'trial',
+    }).then((r) => {
+      if (r.opportunityId) {
+        prisma.garage
+          .update({ where: { id: garage.id }, data: { ghlOpportunityId: r.opportunityId } })
+          .catch((e) => console.error('[PUBLIC_SIGNUP] failed to store ghlOpportunityId:', e));
+      }
     });
 
     console.log(`[PUBLIC_SIGNUP] created account: ${normalizedEmail} → ${businessName} (garage=${garage.id}, agreement=${agreement.id})`);

--- a/backend/src/routes/webhooks/stripe.ts
+++ b/backend/src/routes/webhooks/stripe.ts
@@ -18,6 +18,7 @@ import { sendWelcomeEmail, sendEmail } from '../../utils/email.js';
 import { getStripeClient, STRIPE_TRIAL_DAYS } from '../../services/stripe.js';
 import { purchaseRandomTwilioNumber } from '../onboarding.js';
 import { sendAgentConfigWebhook } from '../config.js';
+import { updateOpportunity, LIVE_STAGE_ID } from '../../services/highlevel.js';
 
 const router = Router();
 
@@ -162,7 +163,7 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   if (!subId) return;
   const garage = await prisma.garage.findFirst({
     where: { stripeSubscriptionId: subId },
-    select: { id: true, businessId: true, includedMinutes: true, subscriptionCostGbp: true, costPerMinuteGbp: true, vatRate: true, subscriptionActivatedAt: true },
+    select: { id: true, businessId: true, includedMinutes: true, subscriptionCostGbp: true, costPerMinuteGbp: true, vatRate: true, subscriptionActivatedAt: true, ghlOpportunityId: true },
   });
   if (!garage) return; // not one of ours (e.g. an existing DD customer) — ignore
 
@@ -200,9 +201,18 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     },
   });
 
-  // First successful charge = trial converted → mark the garage activated.
+  // First successful charge = trial converted → mark the garage activated, and
+  // promote its HighLevel opportunity from "Free trial live" to "Live and £££".
   if (!garage.subscriptionActivatedAt) {
     await prisma.garage.update({ where: { id: garage.id }, data: { subscriptionActivatedAt: new Date() } });
+    if (garage.ghlOpportunityId && (invoice.amount_paid ?? 0) > 0) {
+      void updateOpportunity(garage.ghlOpportunityId, {
+        stageId: LIVE_STAGE_ID,
+        monetaryValueGbp: garage.subscriptionCostGbp,
+      }).then((ok) =>
+        console.log(`[STRIPE_WEBHOOK] HL opportunity ${garage.ghlOpportunityId} → Live (${ok ? 'ok' : 'failed'})`),
+      );
+    }
   }
   console.log(`[STRIPE_WEBHOOK] invoice paid garage=${garage.id} stripeInvoice=${invoice.id} £${(invoice.amount_paid ?? 0) / 100}`);
 }

--- a/backend/src/services/highlevel.ts
+++ b/backend/src/services/highlevel.ts
@@ -14,11 +14,15 @@ const GHL_BASE_URL = (process.env.GHL_API_BASE || 'https://services.leadconnecto
 // HighLevel pipeline IDs. Pinned via env so a rename in HL doesn't break our
 // CRM sync (and so we don't pay an API roundtrip on every opportunity create).
 //   GHL_PIPELINE_ID       — "Onboarding Newest"
-//   GHL_SIGNUP_STAGE_ID   — "Live and £££..." (paid signups land here)
+//   GHL_SIGNUP_STAGE_ID   — "Live and £££..." (converted/paid accounts land here)
 //   GHL_LEAD_STAGE_ID     — "Enquiry Received & Demo Links sent" (new leads)
+//   GHL_TRIAL_STAGE_ID    — "Free trial live" (new 14-day Assist trials land here)
 const PIPELINE_ID     = process.env.GHL_PIPELINE_ID     ?? '';
 const SIGNUP_STAGE_ID = process.env.GHL_SIGNUP_STAGE_ID ?? '';
 const LEAD_STAGE_ID   = process.env.GHL_LEAD_STAGE_ID   ?? '';
+const TRIAL_STAGE_ID  = process.env.GHL_TRIAL_STAGE_ID  ?? '';
+// The "Live and £££" stage an opportunity is promoted to once the trial converts.
+export const LIVE_STAGE_ID = SIGNUP_STAGE_ID;
 
 const HEADERS = {
   Authorization: `Bearer ${GHL_PIT}`,
@@ -40,6 +44,7 @@ export interface UpsertContactArgs {
   email: string;
   phone?: string;
   companyName: string;
+  website?: string;
   source?: string;
   tags?: string[];
 }
@@ -67,6 +72,7 @@ export async function upsertContact(args: UpsertContactArgs): Promise<ContactRes
     tags: args.tags ?? ['website-lead'],
   };
   if (args.phone) body.phone = args.phone;
+  if (args.website) body.website = args.website;
 
   try {
     const res = await fetch(`${GHL_BASE_URL}/contacts/upsert`, {
@@ -87,7 +93,7 @@ export async function upsertContact(args: UpsertContactArgs): Promise<ContactRes
   }
 }
 
-export type OpportunityKind = 'signup' | 'lead';
+export type OpportunityKind = 'signup' | 'lead' | 'trial';
 
 export interface CreateOpportunityArgs {
   contactId: string;
@@ -102,7 +108,10 @@ export async function createOpportunity(args: CreateOpportunityArgs): Promise<{ 
     console.warn('[HL] skipping opportunity — set GHL_PIPELINE_ID / GHL_SIGNUP_STAGE_ID / GHL_LEAD_STAGE_ID in env.');
     return { id: null };
   }
-  const stageId = args.kind === 'signup' ? SIGNUP_STAGE_ID : LEAD_STAGE_ID;
+  const stageId =
+    args.kind === 'signup' ? SIGNUP_STAGE_ID :
+    args.kind === 'trial'  ? (TRIAL_STAGE_ID || SIGNUP_STAGE_ID) :
+    LEAD_STAGE_ID;
 
   const body: Record<string, unknown> = {
     pipelineId: PIPELINE_ID,
@@ -133,32 +142,68 @@ export async function createOpportunity(args: CreateOpportunityArgs): Promise<{ 
   }
 }
 
+// Move an existing opportunity to a different stage (and optionally update its
+// value). Used to promote a trial opportunity to "Live and £££" on conversion.
+// Tolerant: logs + returns false on failure, never throws.
+export async function updateOpportunity(
+  opportunityId: string,
+  args: { stageId?: string; monetaryValueGbp?: number; status?: string },
+): Promise<boolean> {
+  if (!highlevelConfigured() || !opportunityId) return false;
+  const body: Record<string, unknown> = {};
+  if (args.stageId) body.pipelineStageId = args.stageId;
+  if (typeof args.monetaryValueGbp === 'number') body.monetaryValue = args.monetaryValueGbp;
+  if (args.status) body.status = args.status;
+  if (Object.keys(body).length === 0) return false;
+  try {
+    const res = await fetch(`${GHL_BASE_URL}/opportunities/${opportunityId}`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      console.error(`[HL] opportunity update failed ${res.status}:`, text.slice(0, 300));
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error('[HL] opportunity update threw:', err);
+    return false;
+  }
+}
+
 // Convenience helper: upsert a contact and create an opportunity in one go.
 // Both calls are tolerant — failures log + return null but never throw.
+// Returns the created opportunity id (so callers can store it and promote the
+// opportunity later, e.g. when a trial converts to paid).
 export async function pushSignupToHighlevel(args: {
   name: string;
   email: string;
   phone?: string;
   companyName: string;
+  website?: string;
   source: string;
   tags?: string[];
   opportunityName: string;
   monetaryValueGbp?: number;
   kind: OpportunityKind;
-}): Promise<void> {
+}): Promise<{ opportunityId: string | null }> {
   const contact = await upsertContact({
     name: args.name,
     email: args.email,
     phone: args.phone,
     companyName: args.companyName,
+    website: args.website,
     source: args.source,
     tags: args.tags,
   });
-  if (!contact.contactId) return;
-  await createOpportunity({
+  if (!contact.contactId) return { opportunityId: null };
+  const opp = await createOpportunity({
     contactId: contact.contactId,
     name: args.opportunityName,
     monetaryValueGbp: args.monetaryValueGbp,
     kind: args.kind,
   });
+  return { opportunityId: opp.id };
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model Garage {
   stripeCustomerId     String?
   stripeSubscriptionId String?
   trialEndsAt          DateTime?
+  ghlOpportunityId     String?   // HighLevel opportunity for this account (created at trial signup, promoted to "Live" on conversion)
   hasMessagingAccess Boolean @default(false)
 
   // Billing Configuration


### PR DESCRIPTION
Trial signups create a HighLevel opportunity in Free-trial-live (£200, website); the first post-trial Stripe charge promotes it to Live and £££. Live on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)