### PR TITLE
Account arrears lockout: auto-lock on Stripe payment failure + branded emails

### DIFF
--- a/app/agent-setup/_components/IdentityTab.tsx
+++ b/app/agent-setup/_components/IdentityTab.tsx
@@ -20,7 +20,7 @@ export default function IdentityTab({ config, save, isSaving, twilioNumber }: Pr
       title: 'Branch identity',
       description: "Tells the agent who it's representing. Used in the greeting and every prompt.",
       branchName: 'Branch name',
-      branchNameHint: 'e.g. Speedy Spanners — Reading',
+      branchNameHint: 'e.g. Riverside Motors — Reading',
       branchNameRequired: "Branch name is required so the agent knows who it's representing.",
       agentName: 'Agent name',
       agentNameHint: "What the agent calls itself on calls (e.g. the voice's name, or your own — like 'Jamie')",
@@ -43,7 +43,7 @@ export default function IdentityTab({ config, save, isSaving, twilioNumber }: Pr
       description:
         "Indique à l'agent qui il représente. Utilisé dans le message d'accueil et chaque prompt.",
       branchName: "Nom de l'agence",
-      branchNameHint: 'p. ex. Speedy Spanners — Reading',
+      branchNameHint: 'p. ex. Riverside Motors — Reading',
       branchNameRequired: "Le nom de l'agence est requis pour que l'agent sache qui il représente.",
       agentName: "Nom de l'agent",
       agentNameHint:
@@ -152,7 +152,7 @@ export default function IdentityTab({ config, save, isSaving, twilioNumber }: Pr
           type="email"
           value={emailAddress}
           onChange={(e) => setEmailAddress(e.target.value)}
-          placeholder="hello@speedyspanners.co.uk"
+          placeholder="hello@yourgarage.co.uk"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
         />
       </Field>
@@ -172,7 +172,7 @@ export default function IdentityTab({ config, save, isSaving, twilioNumber }: Pr
           type="url"
           value={websiteUrl}
           onChange={(e) => setWebsiteUrl(e.target.value)}
-          placeholder="https://speedyspanners.co.uk"
+          placeholder="https://yourgarage.co.uk"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
         />
       </Field>

--- a/app/components/AppShell.tsx
+++ b/app/components/AppShell.tsx
@@ -7,6 +7,7 @@ import Sidebar from './Sidebar';
 import Navbar from './Navbar';
 import SetupWizard from './SetupWizard';
 import SupportChatWidget from './SupportChatWidget';
+import PaymentBlocker from './PaymentBlocker';
 import {
   ALL_ASSIGNED_BRANCHES_IDENTIFIER,
   BranchScopeProvider,
@@ -26,7 +27,7 @@ import {
   setGarageId,
   setGarages,
 } from '../lib/auth';
-import { fetchGarages, fetchPendingAgreement } from '../lib/api';
+import { fetchGarages, fetchPendingAgreement, fetchArrearsStatus } from '../lib/api';
 import { fetchOnboardingStatus } from '../lib/onboarding';
 import type { GarageSummary } from '../types';
 import { useLang } from '@/app/i18n/LocaleProvider';
@@ -62,6 +63,7 @@ export default function AppShell({ children }: { children: ReactNode }) {
   const [messagesNeedingAttention, setMessagesNeedingAttention] = useState(0);
   const [conversationsNeedingAttention, setConversationsNeedingAttention] = useState(0);
   const [setupWizardOpen, setSetupWizardOpen] = useState(false);
+  const [isLocked, setIsLocked] = useState(false);
   const [wizardAgentType, setWizardAgentType] = useState<'assist' | 'automate'>('assist');
   const branchRoles = useMemo(() => getUserBranchRoles(), []);
   const managedGarageIds = useMemo(
@@ -225,6 +227,31 @@ export default function AppShell({ children }: { children: ReactNode }) {
     };
   }, [shouldShowChrome, isReady, userId, isStaffUser, pathname, router]);
 
+  // Arrears gate — if the selected garage is locked for non-payment, show the full-screen
+  // payment blocker. Internal staff are never blocked. Polled so an already-open session
+  // locks the moment the 2-day grace elapses.
+  useEffect(() => {
+    if (!shouldShowChrome || !isReady || !garageId || isStaffUser) {
+      setIsLocked(false);
+      return;
+    }
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const { lockedGarageIds } = await fetchArrearsStatus();
+        if (!cancelled) setIsLocked(lockedGarageIds.includes(garageId));
+      } catch {
+        /* fail open — never block the portal on a transient status-check error */
+      }
+    };
+    void check();
+    const interval = setInterval(check, 60000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [shouldShowChrome, isReady, garageId, isStaffUser]);
+
   // Check if setup wizard should be shown
   useEffect(() => {
     const checkSetupWizard = async () => {
@@ -369,6 +396,16 @@ export default function AppShell({ children }: { children: ReactNode }) {
         <div className="text-sm text-slate-500">{c.preparing}</div>
       </div>
     </div>
+  ) : isLocked && !isStaffUser ? (
+    <PaymentBlocker
+      garageName={garages.find((g) => g.id === garageId)?.name}
+      onLogout={() => {
+        clearSession();
+        setIsStaffUser(false);
+        setUserIdState(null);
+        router.replace('/login');
+      }}
+    />
   ) : (
     <div className="flex min-h-screen bg-slate-50 text-slate-900">
       <Sidebar

--- a/app/components/PaymentBlocker.tsx
+++ b/app/components/PaymentBlocker.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+/**
+ * Full-screen payment blocker shown when the selected garage is locked for non-payment
+ * (arrears). Replaces the whole portal — the user can't do anything except contact us or
+ * log out — while their AI receptionist keeps answering calls in the background.
+ */
+export default function PaymentBlocker({
+  garageName,
+  onLogout,
+}: {
+  garageName?: string | null;
+  onLogout: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-[100] flex min-h-screen items-center justify-center bg-[#09203c] p-6">
+      <div className="w-full max-w-lg overflow-hidden rounded-2xl bg-[#1a3a52] shadow-2xl">
+        <div className="bg-gradient-to-br from-amber-500 to-amber-600 px-8 py-8 text-center">
+          <div className="mb-2 text-4xl">🔒</div>
+          <h1 className="text-2xl font-semibold text-white">Your account is in arrears</h1>
+          {garageName ? (
+            <p className="mt-1 text-sm text-white/90">{garageName}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-5 px-8 py-8 text-slate-200">
+          <p className="text-base leading-relaxed">
+            We weren&apos;t able to take your latest ReceptionMate payment, so access to your
+            portal is paused until the account is brought up to date.
+          </p>
+          <p className="text-base leading-relaxed">
+            Don&apos;t worry — your AI receptionist is <strong>still answering your calls</strong>.
+            As soon as payment is received, everything unlocks straight away.
+          </p>
+
+          <div className="rounded-lg border border-[#1e4a66] bg-[#0d2739] p-5 text-sm leading-relaxed text-slate-300">
+            To settle your account or sort out a payment issue, get in touch and we&apos;ll get
+            you back up and running:
+            <div className="mt-3">
+              <a
+                href="mailto:hello@receptionmate.co.uk?subject=Bring%20my%20account%20up%20to%20date"
+                className="font-semibold text-blue-400 hover:text-blue-300"
+              >
+                hello@receptionmate.co.uk
+              </a>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 pt-1 sm:flex-row">
+            <a
+              href="mailto:hello@receptionmate.co.uk?subject=Bring%20my%20account%20up%20to%20date"
+              className="flex-1 rounded-lg bg-gradient-to-br from-amber-500 to-amber-600 px-5 py-3 text-center text-sm font-semibold text-white transition hover:from-amber-400 hover:to-amber-500"
+            >
+              Bring my account up to date
+            </a>
+            <button
+              type="button"
+              onClick={onLogout}
+              className="rounded-lg border border-[#1e4a66] px-5 py-3 text-center text-sm font-semibold text-slate-300 transition hover:bg-[#0d2739]"
+            >
+              Log out
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/jodie-config/tabs/IdentityTab.tsx
+++ b/app/jodie-config/tabs/IdentityTab.tsx
@@ -45,7 +45,7 @@ export default function IdentityTab({ config, save, isSaving }: Props) {
       isSaving={isSaving}
       saveDisabled={branchNameMissing}
     >
-      <Field label="Branch name" required hint="e.g. Speedy Spanners — Reading">
+      <Field label="Branch name" required hint="e.g. Riverside Motors — Reading">
         <input
           type="text"
           value={branchName}
@@ -74,7 +74,7 @@ export default function IdentityTab({ config, save, isSaving }: Props) {
           type="email"
           value={emailAddress}
           onChange={(e) => setEmailAddress(e.target.value)}
-          placeholder="hello@speedyspanners.co.uk"
+          placeholder="hello@yourgarage.co.uk"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
         />
       </Field>
@@ -94,7 +94,7 @@ export default function IdentityTab({ config, save, isSaving }: Props) {
           type="url"
           value={websiteUrl}
           onChange={(e) => setWebsiteUrl(e.target.value)}
-          placeholder="https://speedyspanners.co.uk"
+          placeholder="https://yourgarage.co.uk"
           className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-brand-600 focus:outline-none focus:ring-1 focus:ring-brand-600"
         />
       </Field>

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -144,6 +144,13 @@ export const fetchGarages = async (): Promise<GaragesResponse> => {
   return data;
 };
 
+// Which of the user's garages are locked for non-payment (arrears). The portal shows a
+// full-screen payment blocker when the selected garage is in this list.
+export const fetchArrearsStatus = async (): Promise<{ lockedGarageIds: string[] }> => {
+  const { data } = await api.get<{ lockedGarageIds: string[] }>(`/api/billing/arrears-status`);
+  return data;
+};
+
 export const fetchAgentConfiguration = async (
   garageId?: string
 ): Promise<AgentConfigurationResponse> => {

--- a/backend/src/routes/billing-status.ts
+++ b/backend/src/routes/billing-status.ts
@@ -1,0 +1,51 @@
+// Lightweight arrears/lockout status for the logged-in user's garages. The portal
+// polls this on load to decide whether to show the full-screen payment blocker.
+// Available to ALL of a garage's users (not just managers) — everyone gets blocked.
+// Internal ReceptionMate staff are never blocked.
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { prisma } from '../db.js';
+import { authenticate } from '../middleware/auth.js';
+import { resolveAllowedGarages } from '../utils/auth.js';
+import { isGarageLocked } from '../utils/arrears.js';
+
+const router = Router();
+
+router.get('/billing/arrears-status', authenticate, async (req: Request, res: Response) => {
+  // Internal staff are never locked out — they need portal access to support customers.
+  if (req.user?.role === 'RECEPTIONMATE_STAFF') {
+    return res.json({ lockedGarageIds: [] });
+  }
+
+  const garageIds = resolveAllowedGarages(req.user);
+  if (garageIds.length === 0) return res.json({ lockedGarageIds: [] });
+
+  try {
+    const garages = await prisma.garage.findMany({
+      where: { id: { in: garageIds } },
+      select: { id: true, accessRestricted: true, paymentFailedAt: true },
+    });
+
+    const now = new Date();
+    const lockedGarageIds = garages.filter((g) => isGarageLocked(g, now)).map((g) => g.id);
+
+    // Persist the flag for any garage that has just crossed the grace window but whose
+    // accessRestricted flag hasn't been flipped by the backstop sweep yet, so the
+    // server-side call-content withholding + arrears emails engage immediately.
+    const toFlip = garages
+      .filter((g) => !g.accessRestricted && isGarageLocked(g, now))
+      .map((g) => g.id);
+    if (toFlip.length > 0) {
+      await prisma.garage.updateMany({ where: { id: { in: toFlip } }, data: { accessRestricted: true } });
+    }
+
+    return res.json({ lockedGarageIds });
+  } catch (err) {
+    console.error('[ARREARS] status check failed:', err);
+    // Fail open — never lock someone out because of a transient error.
+    return res.json({ lockedGarageIds: [] });
+  }
+});
+
+export default router;

--- a/backend/src/routes/webhooks/stripe.ts
+++ b/backend/src/routes/webhooks/stripe.ts
@@ -14,7 +14,8 @@ import { Router } from 'express';
 import express from 'express';
 import Stripe from 'stripe';
 import { prisma } from '../../db.js';
-import { sendWelcomeEmail, sendEmail } from '../../utils/email.js';
+import { sendWelcomeEmail, sendEmail, sendArrearsWarningEmail } from '../../utils/email.js';
+import { ARREARS_GRACE_DAYS } from '../../utils/arrears.js';
 import { getStripeClient, STRIPE_TRIAL_DAYS } from '../../services/stripe.js';
 import { purchaseRandomTwilioNumber } from '../onboarding.js';
 import { sendAgentConfigWebhook } from '../config.js';
@@ -201,6 +202,12 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
     },
   });
 
+  // Payment landed → clear any arrears state (unlock the account + stop the timer).
+  await prisma.garage.updateMany({
+    where: { id: garage.id, OR: [{ paymentFailedAt: { not: null } }, { accessRestricted: true }] },
+    data: { paymentFailedAt: null, accessRestricted: false },
+  });
+
   // First successful charge = trial converted → mark the garage activated, and
   // promote its HighLevel opportunity from "Free trial live" to "Live and £££".
   if (!garage.subscriptionActivatedAt) {
@@ -217,18 +224,50 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
   console.log(`[STRIPE_WEBHOOK] invoice paid garage=${garage.id} stripeInvoice=${invoice.id} £${(invoice.amount_paid ?? 0) / 100}`);
 }
 
-// ── a subscription charge failed: log + notify (Stripe handles retries/dunning itself) ──
+// ── a subscription charge failed: start the arrears timer, warn the garage, notify ops.
+// Stripe keeps retrying (dunning); after the grace window the backstop sweep locks the
+// account. A later invoice.payment_succeeded clears everything.
 async function handleInvoiceFailed(invoice: Stripe.Invoice): Promise<void> {
   const subId = invoiceSubId(invoice);
   if (!subId) return;
-  const garage = await prisma.garage.findFirst({ where: { stripeSubscriptionId: subId }, select: { id: true, name: true } });
+  const garage = await prisma.garage.findFirst({
+    where: { stripeSubscriptionId: subId },
+    select: {
+      id: true,
+      name: true,
+      paymentFailedAt: true,
+      business: { select: { billingEmail: true, contactEmail: true } },
+      agentConfiguration: { select: { branchName: true, notificationEmails: true } },
+    },
+  });
   if (!garage) return;
   console.warn(`[STRIPE_WEBHOOK] invoice payment FAILED garage=${garage.id} (${garage.name}) stripeInvoice=${invoice.id}`);
+
+  // Start the arrears clock on the first failure; leave it running on subsequent retries.
+  if (!garage.paymentFailedAt) {
+    await prisma.garage.update({ where: { id: garage.id }, data: { paymentFailedAt: new Date() } });
+  }
+
+  // Warn the garage — billing email + call/message notification emails (deduped).
+  const recipients = Array.from(new Set([
+    garage.business?.billingEmail,
+    garage.business?.contactEmail,
+    ...(garage.agentConfiguration?.notificationEmails ?? []),
+  ].filter((e): e is string => Boolean(e && e.includes('@')))));
+  if (recipients.length > 0) {
+    void sendArrearsWarningEmail(recipients, {
+      branchName: garage.agentConfiguration?.branchName || garage.name,
+      portalUrl: PORTAL_URL,
+      graceDays: ARREARS_GRACE_DAYS,
+    }).catch((e) => console.error('[STRIPE_WEBHOOK] arrears warning email failed:', e));
+  }
+
+  // Internal heads-up to ops.
   void sendEmail({
     to: [OPS_EMAIL],
     subject: `Assist payment failed — ${garage.name}`,
-    text: `Stripe subscription payment failed for ${garage.name} (garage ${garage.id}, invoice ${invoice.id}). Stripe will retry automatically; check the dashboard if it keeps failing.`,
-    html: `<p>Stripe subscription payment failed for <strong>${garage.name}</strong> (garage ${garage.id}, invoice ${invoice.id}).</p><p>Stripe will retry automatically (dunning); check the dashboard if it keeps failing.</p>`,
+    text: `Stripe subscription payment failed for ${garage.name} (garage ${garage.id}, invoice ${invoice.id}). The garage has been warned; access auto-locks after ${ARREARS_GRACE_DAYS} days if unpaid. Stripe will retry automatically.`,
+    html: `<p>Stripe subscription payment failed for <strong>${garage.name}</strong> (garage ${garage.id}, invoice ${invoice.id}).</p><p>The garage has been warned; access auto-locks after ${ARREARS_GRACE_DAYS} days if unpaid. Stripe will retry automatically (dunning).</p>`,
   }).catch(() => {});
 }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -41,6 +41,8 @@ import agreementsRouter from './routes/agreements.js';
 import supportRouter from './routes/support.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { initializeScheduledReports } from './utils/scheduler.js';
+import { startArrearsSweep } from './utils/arrears.js';
+import billingStatusRouter from './routes/billing-status.js';
 
 const app = express();
 
@@ -115,6 +117,7 @@ app.use('/api', messagesRouter);
 app.use('/api', billingRouter);
 app.use('/api', billingActivationRouter);
 app.use('/api/customer/billing', customerBillingRouter);
+app.use('/api', billingStatusRouter);
 app.use('/api', socialConnectionsRouter);
 app.use('/api', oauthRouter);
 app.use('/api', smsRouter);
@@ -147,4 +150,7 @@ app.listen(port, '0.0.0.0', () => {
 
   // Initialize scheduled report jobs
   initializeScheduledReports();
+
+  // Backstop sweep: auto-lock garages whose Stripe payment has been failed past the grace window.
+  startArrearsSweep();
 });

--- a/backend/src/utils/arrears.ts
+++ b/backend/src/utils/arrears.ts
@@ -1,0 +1,66 @@
+// Shared arrears / account-lockout timing.
+//
+// When a Stripe card charge fails we stamp Garage.paymentFailedAt. The garage keeps
+// full access during a short grace period; once paymentFailedAt is older than the
+// grace window the garage is "locked" — accessRestricted flips true, which withholds
+// call content, swaps per-call emails for the arrears notice, and (in the portal)
+// shows a full-screen payment blocker. A successful payment clears both fields.
+//
+// The lock is TIME-DERIVED so it needs no cron: any code path (webhook, backstop
+// sweep, or the arrears-status endpoint) can compute it from paymentFailedAt.
+
+import { prisma } from '../db.js';
+
+export const ARREARS_GRACE_DAYS = 2;
+export const ARREARS_GRACE_MS = ARREARS_GRACE_DAYS * 24 * 60 * 60 * 1000;
+
+/** True once a failed payment has been outstanding longer than the grace window. */
+export function isPastArrearsGrace(
+  paymentFailedAt: Date | string | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!paymentFailedAt) return false;
+  return now.getTime() - new Date(paymentFailedAt).getTime() >= ARREARS_GRACE_MS;
+}
+
+/**
+ * Effective lock for a garage. A garage is locked if it's been manually flagged
+ * (accessRestricted) OR its failed payment is past the grace window. Used so the
+ * portal blocker engages the moment the timer elapses, even before the backstop
+ * sweep has flipped the persisted flag.
+ */
+export function isGarageLocked(
+  garage: { accessRestricted?: boolean | null; paymentFailedAt?: Date | string | null },
+  now: Date = new Date(),
+): boolean {
+  return Boolean(garage.accessRestricted) || isPastArrearsGrace(garage.paymentFailedAt, now);
+}
+
+let arrearsSweepTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Flip accessRestricted → true for any garage whose failed payment is now past the grace
+ * window. Backstop so the call-content withholding + arrears emails engage even for garages
+ * that never open the portal. Cheap: only matches unlocked, past-grace rows.
+ */
+export async function sweepArrearsLocks(): Promise<void> {
+  try {
+    const cutoff = new Date(Date.now() - ARREARS_GRACE_MS);
+    const res = await prisma.garage.updateMany({
+      where: { accessRestricted: false, paymentFailedAt: { not: null, lte: cutoff } },
+      data: { accessRestricted: true },
+    });
+    if (res.count > 0) {
+      console.log(`[ARREARS] auto-locked ${res.count} garage(s) past the ${ARREARS_GRACE_DAYS}-day grace`);
+    }
+  } catch (e) {
+    console.error('[ARREARS] sweep failed:', e);
+  }
+}
+
+/** Start the periodic arrears sweep (runs once immediately, then on an interval). */
+export function startArrearsSweep(intervalMs = 30 * 60 * 1000): void {
+  if (arrearsSweepTimer) return;
+  void sweepArrearsLocks();
+  arrearsSweepTimer = setInterval(() => void sweepArrearsLocks(), intervalMs);
+}

--- a/backend/src/utils/email.ts
+++ b/backend/src/utils/email.ts
@@ -1047,3 +1047,230 @@ This is an automated email from ReceptionMate
     text,
   });
 };
+
+interface ArrearsCallNoticeEmailData {
+  branchName: string;
+  createdAt: string;
+  portalUrl: string;
+}
+
+// ReceptionMate brand assets for transactional emails (match the portal / marketing site).
+const RM_LOGO_URL = 'https://storage.googleapis.com/msgsndr/2UadumwHCXxeU9yxBIRC/media/65cf28be6e4392e608cca8a9.png';
+const RM_BRAND = '#3426cf';       // brand-600 (primary indigo)
+const RM_BRAND_DARK = '#281eb0';  // brand-700
+
+/**
+ * Shared branded shell for arrears emails: white card on light grey, an indigo header
+ * band carrying the ReceptionMate logo, and a consistent footer. Callers pass the inner
+ * body HTML. Keeps every arrears email on-brand with the portal.
+ */
+const arrearsEmailShell = (bodyHtml: string): string => `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f1f2f9;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #f1f2f9;">
+    <tr>
+      <td style="padding: 40px 20px;">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" style="margin: 0 auto; background-color: #ffffff; border-radius: 16px; overflow: hidden; box-shadow: 0 4px 24px rgba(52,38,207,0.12);">
+          <tr>
+            <td style="padding: 32px; background-color: ${RM_BRAND}; text-align: center;">
+              <img src="${RM_LOGO_URL}" alt="ReceptionMate" height="120" style="height: 120px; width: auto; display: inline-block;" />
+            </td>
+          </tr>
+          ${bodyHtml}
+          <tr>
+            <td style="padding: 24px 32px; background-color: #f7f7fb; border-top: 1px solid #e9eaf5;">
+              <p style="margin: 0; font-size: 12px; line-height: 1.5; color: #8b90b0; text-align: center;">
+                This is an automated email from ReceptionMate<br/>
+                © ${new Date().getFullYear()} ReceptionMate. All rights reserved.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+/**
+ * Arrears notice — sent instead of the full call summary when a garage is flagged
+ * accessRestricted. Deliberately contains NO call content (no caller, summary, transcript
+ * or recording): it only confirms a call was handled and that the details are on hold
+ * until the account is brought up to date.
+ */
+export const sendArrearsCallNoticeEmail = async (
+  notificationEmails: string[],
+  data: ArrearsCallNoticeEmailData,
+): Promise<boolean> => {
+  if (notificationEmails.length === 0) {
+    console.log('No notification emails configured for arrears call notice');
+    return false;
+  }
+
+  const date = new Date(data.createdAt);
+  const formattedDate = date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  const html = arrearsEmailShell(`
+          <tr>
+            <td style="padding: 36px 32px 8px; text-align: center;">
+              <h1 style="margin: 0; font-size: 22px; font-weight: 600; color: #1d1a72;">📞 We handled a call for you</h1>
+              <p style="margin: 8px 0 0; font-size: 15px; color: #6b7194;">${data.branchName}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 32px 0;">
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.6; color: #3a3f5c;">
+                Your ReceptionMate AI receptionist answered a call for you on <strong>${formattedDate}</strong>.
+              </p>
+              <p style="margin: 0 0 20px; font-size: 16px; line-height: 1.6; color: #3a3f5c;">
+                Your account is currently <strong>in arrears</strong>, so the caller's details, the call summary,
+                transcript and recording are <strong>on hold</strong>. As soon as your account is brought up to
+                date, everything will be unlocked in your portal.
+              </p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td style="padding: 16px 20px; background-color: #fff8ec; border: 1px solid #f6dfae; border-radius: 10px; font-size: 14px; line-height: 1.5; color: #8a6417;">
+                    <strong>📞 Call handled:</strong> ${formattedDate}<br/>
+                    <strong>🔒 Details:</strong> locked until your account is up to date
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 28px 32px 4px; text-align: center;">
+              <a href="${data.portalUrl}/login" style="display: inline-block; padding: 14px 30px; background-color: ${RM_BRAND}; color: #ffffff; font-size: 15px; font-weight: 600; text-decoration: none; border-radius: 10px;">
+                Bring my account up to date
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 32px 32px; text-align: center;">
+              <p style="margin: 0; font-size: 14px; line-height: 1.6; color: #8b90b0;">
+                Questions? Contact us at <a href="mailto:hello@receptionmate.co.uk" style="color: ${RM_BRAND}; text-decoration: none;">hello@receptionmate.co.uk</a>
+              </p>
+            </td>
+          </tr>`);
+
+  const text = `
+WE HANDLED A CALL FOR YOU
+
+${data.branchName}
+
+Your ReceptionMate AI receptionist answered a call for you on ${formattedDate}.
+
+Your account is currently IN ARREARS, so the caller's details, the call summary, transcript and recording are on hold. As soon as your account is brought up to date, everything will be unlocked in your portal.
+
+Call handled: ${formattedDate}
+Details: locked until your account is up to date
+
+Bring your account up to date: ${data.portalUrl}/login
+
+Questions? Contact us at hello@receptionmate.co.uk
+
+---
+This is an automated email from ReceptionMate
+`;
+
+  return sendEmail({
+    to: notificationEmails,
+    subject: 'We handled a call for you — account update needed',
+    html,
+    text,
+  });
+};
+
+interface ArrearsWarningEmailData {
+  branchName: string;
+  portalUrl: string;
+  graceDays: number;
+}
+
+/**
+ * Payment-failed warning — sent to the garage (billing + notification emails) as soon
+ * as a Stripe card charge fails. Advises the payment failed, that we'll retry, and that
+ * access will be limited if it isn't brought up to date within the grace window.
+ */
+export const sendArrearsWarningEmail = async (
+  recipients: string[],
+  data: ArrearsWarningEmailData,
+): Promise<boolean> => {
+  if (recipients.length === 0) {
+    console.log('No recipients configured for arrears warning email');
+    return false;
+  }
+
+  const html = arrearsEmailShell(`
+          <tr>
+            <td style="padding: 36px 32px 8px; text-align: center;">
+              <h1 style="margin: 0; font-size: 22px; font-weight: 600; color: #1d1a72;">⚠️ We couldn't take your payment</h1>
+              <p style="margin: 8px 0 0; font-size: 15px; color: #6b7194;">${data.branchName}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 32px 0;">
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.6; color: #3a3f5c;">
+                We tried to take your ReceptionMate subscription payment but the card was declined.
+              </p>
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td style="padding: 16px 20px; background-color: #fef3f2; border: 1px solid #fbd5d0; border-radius: 10px; font-size: 15px; line-height: 1.6; color: #7a2b23;">
+                    We'll automatically retry over the next few days. To avoid any interruption, please update your
+                    payment details. If your account isn't brought up to date within <strong>${data.graceDays} days</strong>,
+                    portal access will be limited until payment is received — though your AI receptionist will keep
+                    answering your calls throughout.
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 28px 32px 4px; text-align: center;">
+              <a href="${data.portalUrl}/login" style="display: inline-block; padding: 14px 30px; background-color: ${RM_BRAND}; color: #ffffff; font-size: 15px; font-weight: 600; text-decoration: none; border-radius: 10px;">
+                Update my payment details
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 32px 32px; text-align: center;">
+              <p style="margin: 0; font-size: 14px; line-height: 1.6; color: #8b90b0;">
+                Questions? Contact us at <a href="mailto:hello@receptionmate.co.uk" style="color: ${RM_BRAND}; text-decoration: none;">hello@receptionmate.co.uk</a>
+              </p>
+            </td>
+          </tr>`);
+
+  const text = `
+WE COULDN'T TAKE YOUR PAYMENT
+
+${data.branchName}
+
+We tried to take your ReceptionMate subscription payment but the card was declined.
+
+We'll automatically retry over the next few days. To avoid any interruption, please update your payment details. If your account isn't brought up to date within ${data.graceDays} days, portal access will be limited until payment is received — though your AI receptionist will keep answering your calls throughout.
+
+Update your payment details: ${data.portalUrl}/login
+
+Questions? Contact us at hello@receptionmate.co.uk
+
+---
+This is an automated email from ReceptionMate
+`;
+
+  return sendEmail({
+    to: recipients,
+    subject: 'Payment failed — please update your details',
+    html,
+    text,
+  });
+};

--- a/prisma/migrations/20260707120000_add_garage_access_restricted/migration.sql
+++ b/prisma/migrations/20260707120000_add_garage_access_restricted/migration.sql
@@ -1,0 +1,2 @@
+-- Arrears/access gating flag: withholds call content + shows the payment blocker.
+ALTER TABLE "Garage" ADD COLUMN IF NOT EXISTS "accessRestricted" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20260709120000_add_garage_payment_failed_at/migration.sql
+++ b/prisma/migrations/20260709120000_add_garage_payment_failed_at/migration.sql
@@ -1,0 +1,2 @@
+-- Arrears timer for Stripe card customers: set on a failed charge, cleared on success.
+ALTER TABLE "Garage" ADD COLUMN IF NOT EXISTS "paymentFailedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,13 @@ model Garage {
   ghlOpportunityId     String?   // HighLevel opportunity for this account (created at trial signup, promoted to "Live" on conversion)
   hasMessagingAccess Boolean @default(false)
 
+  // Arrears / access gating. accessRestricted (manual or auto) withholds call content and
+  // shows the portal payment blocker. paymentFailedAt starts the 2-day arrears timer on a
+  // failed Stripe card charge; once past grace the backstop sweep flips accessRestricted.
+  // Both cleared on a successful payment. Stripe-only (GoCardless billing is separate).
+  accessRestricted   Boolean   @default(false)
+  paymentFailedAt    DateTime?
+
   // Billing Configuration
   subscriptionCostGbp Float @default(0)
   includedMinutes     Int   @default(0)


### PR DESCRIPTION
Auto-lock for Assist card customers (GoCardless separate).

**Flow:** Stripe `invoice.payment_failed` → start 2-day arrears timer + branded warning email to billing + notification emails → after grace, backstop sweep sets `accessRestricted` → full-screen portal payment blocker (non-staff only); AI agent keeps answering calls. `invoice.payment_succeeded` clears + unlocks.

- `Garage.accessRestricted` + `paymentFailedAt` (+ migrations)
- `utils/arrears.ts` (grace timing, backstop sweep), `routes/billing-status.ts` (staff-exempt status endpoint)
- `webhooks/stripe.ts` set/clear + warning email
- `utils/email.ts` branded arrears emails (logo + brand indigo #3426cf)
- `AppShell` + `PaymentBlocker` overlay (polled 60s)
- Removed Speedy Spanners UI placeholders

Deployed + verified on the box (lockout confirmed on ReceptionMate Branch test garage). Call-content-withholding wiring (calls.ts/voice.ts) is deployed separately and excluded here — entangled with push-notification WIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)