### PR TITLE
Ops alerts (email + SMS) for website leads + Assist trial signups

### DIFF
--- a/backend/src/routes/public-lead.ts
+++ b/backend/src/routes/public-lead.ts
@@ -6,6 +6,7 @@ import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { z } from 'zod';
 import { sendEmail } from '../utils/email.js';
+import { sendOpsSms } from '../utils/opsAlerts.js';
 import { highlevelConfigured, upsertContact, createOpportunity } from '../services/highlevel.js';
 
 const router = Router();
@@ -35,9 +36,10 @@ router.post('/public/lead', async (req: Request, res: Response) => {
 
   const { name, companyName, email, phone, source, notes } = parsed.data;
 
-  // Always send a team notification email — gives us a fallback record even
+  // Always notify the team by email + SMS — gives us a fallback record even
   // if HighLevel is down for any reason.
   void notifyTeam({ name, companyName, email, phone, source, notes });
+  void notifyTeamSms({ name, companyName, email, phone, source });
 
   if (!highlevelConfigured()) {
     console.warn('[LEAD] HighLevel env vars not set — skipping CRM sync.');
@@ -90,7 +92,23 @@ function humaniseSource(source?: string): string {
     return 'Connect enquiry';
   }
   if (s.includes('assist')) return 'Assist enquiry';
+  if (s.includes('demo')) return 'Book a demo';
   return 'Website enquiry';
+}
+
+// Fire a short SMS to the team so a new lead is impossible to miss.
+function notifyTeamSms(lead: {
+  name: string;
+  companyName: string;
+  email: string;
+  phone: string;
+  source?: string;
+}): void {
+  void sendOpsSms(
+    `New RM lead — ${humaniseSource(lead.source)}\n` +
+      `${lead.name}, ${lead.companyName}\n` +
+      `${lead.phone} · ${lead.email}`,
+  );
 }
 
 async function notifyTeam(lead: {

--- a/backend/src/routes/public-signup.ts
+++ b/backend/src/routes/public-signup.ts
@@ -5,6 +5,7 @@ import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
 import { prisma } from '../db.js';
 import { sendEmail } from '../utils/email.js';
+import { sendOpsSms } from '../utils/opsAlerts.js';
 import { TEMPLATE_VERSION } from '../services/agreementTemplate.js';
 import { pushSignupToHighlevel } from '../services/highlevel.js';
 import { ensureAdminAccessToGarage } from './admin.js';
@@ -270,6 +271,29 @@ router.post('/public-signup', async (req: Request, res: Response) => {
     });
 
     console.log(`[PUBLIC_SIGNUP] created account: ${normalizedEmail} → ${businessName} (garage=${garage.id}, agreement=${agreement.id})`);
+
+    // Ops alert — email + SMS to the team so a new Assist trial signup is impossible to miss.
+    {
+      const details = [
+        `Business: ${businessName}`,
+        `Email: ${normalizedEmail}`,
+        phoneNumber ? `Phone: ${phoneNumber}` : null,
+        websiteUrl ? `Website: ${websiteUrl}` : null,
+      ].filter(Boolean) as string[];
+      void sendEmail({
+        to: ['hello@receptionmate.co.uk'],
+        subject: `New Assist trial signup — ${businessName}`,
+        html:
+          `<div style="font-family:Inter,system-ui,sans-serif;max-width:560px;color:#0f172a;">` +
+          `<h2 style="color:#3426cf;margin:0 0 12px;">New Assist 14-day trial signup 🎉</h2>` +
+          details.map((d) => `<p style="margin:4px 0;">${escapeForEmail(d)}</p>`).join('') +
+          `<p style="margin-top:16px;color:#64748b;font-size:12px;">Opportunity created in HighLevel (Free trial live).</p></div>`,
+        text: `New Assist 14-day trial signup\n\n${details.join('\n')}`,
+      }).catch((e) => console.error('[PUBLIC_SIGNUP] ops signup email failed:', e));
+      void sendOpsSms(
+        `New Assist trial signup 🎉\n${businessName}\n${normalizedEmail}${phoneNumber ? ` · ${phoneNumber}` : ''}`,
+      );
+    }
 
     return res.status(201).json({
       success: true,

--- a/backend/src/utils/opsAlerts.ts
+++ b/backend/src/utils/opsAlerts.ts
@@ -1,0 +1,38 @@
+// Internal ops SMS alerts (new leads, trial signups, etc.). Reuses the Twilio
+// credentials + alphanumeric sender used by the messaging notifications / watchdog.
+// Recipients: OPS_ALERT_SMS_TO (comma-separated), falling back to LEAD_ALERT_SMS_TO
+// then the ops mobile. Best-effort: logs and swallows errors so it never affects
+// the request path.
+import twilio from 'twilio';
+
+const twilioClient =
+  process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN
+    ? twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN)
+    : null;
+
+const SMS_FROM = process.env.TWILIO_SMS_FROM || 'ReceptMate';
+
+const OPS_SMS_TO = (
+  process.env.OPS_ALERT_SMS_TO ||
+  process.env.LEAD_ALERT_SMS_TO ||
+  '+447976500282'
+)
+  .split(',')
+  .map((n) => n.trim())
+  .filter(Boolean);
+
+/** Send a short internal SMS to the ops team. Never throws. */
+export async function sendOpsSms(body: string): Promise<void> {
+  if (OPS_SMS_TO.length === 0) return;
+  if (!twilioClient) {
+    console.warn('[OPS_ALERT] SMS requested but TWILIO credentials not configured — skipping SMS.');
+    return;
+  }
+  for (const to of OPS_SMS_TO) {
+    try {
+      await twilioClient.messages.create({ to, from: SMS_FROM, body: body.slice(0, 1500) });
+    } catch (err) {
+      console.error(`[OPS_ALERT] SMS to ${to} failed:`, err);
+    }
+  }
+}


### PR DESCRIPTION
Text + email the team on new website enquiries and trial signups.

- `opsAlerts.ts`: shared `sendOpsSms` helper
- `public-lead.ts`: SMS on every Automate/Connect enquiry + Book-a-demo (opportunity + email already existed); adds a Book-a-demo source label
- `public-signup.ts`: email + SMS on Assist trial signup

Deployed + verified (email to hello@, SMS to ops mobile). Book-a-demo already routes through `/public/lead` via the marketing LeadModal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)