### PR TITLE
Deferred self-serve Assist signup (no account until sign + card)

### DIFF
--- a/app/agreement/sign/page.tsx
+++ b/app/agreement/sign/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../lib/api';
 import { getSessionToken } from '../../lib/auth';
 import { useLang } from '@/app/i18n/LocaleProvider';
+import TrialCardForm from '@/app/components/TrialCardForm';
 
 export default function AgreementSignPage() {
   return (
@@ -192,6 +193,14 @@ function AgreementSignInner() {
 
   const monthlyTotal = agreement ? agreement.licenceFeeGbp * agreement.centresCount : 0;
 
+  // Set once a public-signup customer has signed: holds the SetupIntent client_secret so we render
+  // the Stripe card form (custom Payment Element) in-page instead of redirecting to stripe.com.
+  const [cardClientSecret, setCardClientSecret] = useState<string | null>(null);
+  // One-time token to set their own password after the card (custom flow → no welcome-email reliance).
+  const [cardResetToken, setCardResetToken] = useState<string | null>(null);
+  // Deferred-account flow: the account is created only after the card, via this pending id.
+  const [cardPendingId, setCardPendingId] = useState<string | null>(null);
+
   const canSubmit =
     !!agreement &&
     signedByName.trim().length > 1 &&
@@ -215,12 +224,14 @@ function AgreementSignInner() {
         ? await signAgreementByToken(token, payload)
         : await signAgreement(agreement.id, payload);
       setDone(true);
-      // Public-signup customers (magic-link path) now go to Stripe Checkout
-      // to pay for their first month before being onboarded. The backend
-      // returns the URL on the sign response.
-      const checkoutUrl = (result as { checkoutUrl?: string | null }).checkoutUrl;
-      if (token && checkoutUrl) {
-        setTimeout(() => { window.location.href = checkoutUrl; }, 1100);
+      // Public-signup customers (magic-link path) enter their card on this page via Stripe's
+      // Payment Element to start the 14-day trial — no redirect. The backend returns the
+      // SetupIntent client_secret; stashing it flips the success screen into the card form.
+      const clientSecret = (result as { checkoutClientSecret?: string | null }).checkoutClientSecret;
+      if (token && clientSecret) {
+        setCardResetToken((result as { passwordSetupToken?: string | null }).passwordSetupToken ?? null);
+        setCardPendingId((result as { pendingSignupId?: string | null }).pendingSignupId ?? null);
+        setCardClientSecret(clientSecret);
         return;
       }
       // For signed-in users (no magic-link token), continue onboarding without
@@ -279,7 +290,17 @@ function AgreementSignInner() {
             </div>
           </div>
 
-          {token ? (
+          {token && cardClientSecret ? (
+            <div className="mt-6">
+              <h2 className="text-sm font-semibold text-slate-900">Start your 14-day free trial</h2>
+              <p className="mt-1 text-xs text-slate-500">
+                Add your card to activate. You won’t be charged today — the trial is free for 14 days.
+              </p>
+              <div className="mt-4">
+                <TrialCardForm clientSecret={cardClientSecret} resetToken={cardResetToken} pendingSignupId={cardPendingId} />
+              </div>
+            </div>
+          ) : token ? (
             <>
               <div className="mt-6 rounded-2xl bg-slate-50 p-5">
                 <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">{c.whatHappensNext}</p>

--- a/app/components/TrialCardForm.tsx
+++ b/app/components/TrialCardForm.tsx
@@ -16,17 +16,19 @@ import {
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '');
 
-function CardForm({ resetToken }: { resetToken?: string | null }) {
+function CardForm({ resetToken, pendingSignupId }: { resetToken?: string | null; pendingSignupId?: string | null }) {
   const stripe = useStripe();
   const elements = useElements();
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [succeeded, setSucceeded] = useState(false);
 
-  // Where to send the customer once the card is confirmed: straight to set their own password
-  // (then they log in — no welcome email needed). Same URL doubles as the 3-D Secure return_url.
+  const chooseUrl = (t: string) => `${window.location.origin}/reset-password?token=${encodeURIComponent(t)}&setup=1`;
+
+  // 3-D Secure return_url (most cards confirm inline and never use this). If we already have a
+  // reset token, go straight to Choose-a-password; otherwise the webhook provisions + welcome email.
   const nextUrl = resetToken
-    ? `${window.location.origin}/reset-password?token=${encodeURIComponent(resetToken)}&setup=1`
+    ? chooseUrl(resetToken)
     : `${window.location.origin}/setup-payment/stripe-complete`;
 
   const handlePay = async (e: React.FormEvent) => {
@@ -50,8 +52,25 @@ function CardForm({ resetToken }: { resetToken?: string | null }) {
       return;
     }
     if (setupIntent && setupIntent.status === 'succeeded') {
-      // Card confirmed inline (no 3-D Secure) — go set a password, then log in.
+      // Card confirmed inline (no 3-D Secure). For the deferred flow, create the account NOW
+      // (returns a set-password token), then go to Choose-a-password → auto-login.
       setSucceeded(true);
+      if (pendingSignupId && !resetToken) {
+        try {
+          const res = await fetch('/internal-api/public/signup-complete', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pendingSignupId }),
+          });
+          const data = await res.json().catch(() => ({}));
+          if (data?.resetToken) {
+            window.location.href = chooseUrl(data.resetToken);
+            return;
+          }
+        } catch {
+          /* fall through — the webhook is the backstop; they can log in via the welcome email */
+        }
+      }
       window.location.href = nextUrl;
       return;
     }
@@ -91,7 +110,7 @@ function CardForm({ resetToken }: { resetToken?: string | null }) {
   );
 }
 
-export default function TrialCardForm({ clientSecret, resetToken }: { clientSecret: string; resetToken?: string | null }) {
+export default function TrialCardForm({ clientSecret, resetToken, pendingSignupId }: { clientSecret: string; resetToken?: string | null; pendingSignupId?: string | null }) {
   return (
     <Elements
       stripe={stripePromise}
@@ -107,7 +126,7 @@ export default function TrialCardForm({ clientSecret, resetToken }: { clientSecr
         },
       }}
     >
-      <CardForm resetToken={resetToken} />
+      <CardForm resetToken={resetToken} pendingSignupId={pendingSignupId} />
     </Elements>
   );
 }

--- a/backend/src/routes/agreements.ts
+++ b/backend/src/routes/agreements.ts
@@ -182,11 +182,9 @@ router.get('/agreements/sign/:token', async (req: Request, res: Response) => {
     include: { user: true },
   });
 
-  if (!tokenRow || tokenRow.consumedAt || tokenRow.expiresAt < new Date()) {
-    return res.status(404).json({ error: 'Sign link not found or expired' });
-  }
-  if (!tokenRow.agreementId) {
-    return res.status(404).json({ error: 'Sign link has no agreement' });
+  if (!tokenRow || tokenRow.consumedAt || tokenRow.expiresAt < new Date() || !tokenRow.agreementId) {
+    // Not a manual/legacy sign token — try a self-serve PendingSignup (deferred-account flow).
+    return renderPendingSignAgreement(req.params.token, res);
   }
 
   const agreement = await prisma.agreement.findUnique({ where: { id: tokenRow.agreementId } });
@@ -228,11 +226,9 @@ router.post('/agreements/sign/:token', async (req: Request, res: Response) => {
   }
 
   const tokenRow = await prisma.signLinkToken.findUnique({ where: { token: req.params.token } });
-  if (!tokenRow || tokenRow.consumedAt || tokenRow.expiresAt < new Date()) {
-    return res.status(404).json({ error: 'Sign link not found or expired' });
-  }
-  if (!tokenRow.agreementId) {
-    return res.status(404).json({ error: 'Sign link has no agreement' });
+  if (!tokenRow || tokenRow.consumedAt || tokenRow.expiresAt < new Date() || !tokenRow.agreementId) {
+    // Not a manual/legacy sign token — try a self-serve PendingSignup (deferred-account flow).
+    return finalisePendingSignature(req.params.token, parsed.data, clientIp(req), req.headers['user-agent'] ?? '', res);
   }
 
   return finaliseSignature({
@@ -422,6 +418,102 @@ async function finaliseSignature(opts: {
       signedAt: updated.signedAt,
       signedByName: updated.signedByName,
     },
+  });
+}
+
+// ── Self-serve deferred-account flow: the sign token maps to a PendingSignup, not an Agreement.
+// No account exists yet; we render/sign against the pending row and create the Stripe trial. The
+// real account is created only after the card is confirmed (POST /public/signup-complete + webhook).
+function pendingAgreementInputs(businessName: string) {
+  return {
+    type: 'saas',
+    clientName: businessName,
+    setupFeeGbp: 0,
+    licenceFeeGbp: 200,
+    centresCount: 1,
+    licences: ['assist'] as string[],
+    goLiveDate: null as Date | null,
+  };
+}
+
+async function renderPendingSignAgreement(token: string, res: Response) {
+  const pending = await prisma.pendingSignup.findUnique({ where: { signToken: token } });
+  if (!pending || pending.status === 'completed' || pending.expiresAt < new Date()) {
+    return res.status(404).json({ error: 'Sign link not found or expired' });
+  }
+  const html = buildSnapshot(pendingAgreementInputs(pending.businessName));
+  return res.json({
+    agreement: {
+      id: 'pending', clientName: pending.businessName, setupFeeGbp: 0, licenceFeeGbp: 200,
+      centresCount: 1, licences: ['assist'], goLiveDate: null, status: 'sent', type: 'saas', version: TEMPLATE_VERSION,
+    },
+    customerEmail: pending.email,
+    html,
+    css: AGREEMENT_CSS,
+  });
+}
+
+async function finalisePendingSignature(
+  token: string,
+  data: { signedByName: string; signedByPosition: string; signatureDataUrl: string; signerEmail?: string },
+  ip: string,
+  userAgent: string,
+  res: Response,
+) {
+  const pending = await prisma.pendingSignup.findUnique({ where: { signToken: token } });
+  if (!pending || pending.expiresAt < new Date()) {
+    return res.status(404).json({ error: 'Sign link not found or expired' });
+  }
+  if (pending.createdGarageId) return res.status(409).json({ error: 'Already completed' });
+
+  const now = new Date();
+  const snapshot = buildSnapshot(pendingAgreementInputs(pending.businessName), {
+    name: data.signedByName, position: data.signedByPosition, at: now, signatureImage: data.signatureDataUrl,
+  });
+
+  // Create the Stripe 14-day trial keyed to this pending signup (metadata carries pendingSignupId).
+  let checkoutClientSecret: string | null = null;
+  let stripeCustomerId: string | null = null;
+  let stripeSubscriptionId: string | null = null;
+  if (stripeConfigured()) {
+    try {
+      const trial = await createAssistTrialSubscription({
+        email: pending.email, businessName: pending.businessName, pendingSignupId: pending.id,
+      });
+      checkoutClientSecret = trial.clientSecret;
+      stripeCustomerId = trial.customerId;
+      stripeSubscriptionId = trial.subscriptionId;
+    } catch (e) {
+      console.error('[AGREEMENT_SIGN] pending Stripe trial create failed:', e);
+    }
+  }
+  const trialEndsAt = new Date(Date.now() + STRIPE_TRIAL_DAYS * 24 * 60 * 60 * 1000);
+  await prisma.pendingSignup.update({
+    where: { id: pending.id },
+    data: {
+      status: 'signed',
+      signedByName: data.signedByName,
+      signedByPosition: data.signedByPosition,
+      signatureImage: data.signatureDataUrl,
+      signedFromIp: ip,
+      signedUserAgent: userAgent.slice(0, 500),
+      signedAt: now,
+      templateSnapshot: snapshot,
+      agreementVersion: TEMPLATE_VERSION,
+      email: data.signerEmail ? data.signerEmail.toLowerCase() : pending.email,
+      stripeCustomerId,
+      stripeSubscriptionId,
+      trialEndsAt,
+    },
+  });
+
+  return res.json({
+    success: true,
+    nextStep: 'payment',
+    checkoutClientSecret,
+    passwordSetupToken: null, // account isn't created until the card confirms — set then, via /public/signup-complete
+    pendingSignupId: pending.id,
+    agreement: { id: 'pending', status: 'signed', signedAt: now, signedByName: data.signedByName },
   });
 }
 

--- a/backend/src/routes/public-lead.ts
+++ b/backend/src/routes/public-lead.ts
@@ -7,7 +7,8 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { sendEmail } from '../utils/email.js';
 import { sendOpsSms } from '../utils/opsAlerts.js';
-import { highlevelConfigured, upsertContact, createOpportunity } from '../services/highlevel.js';
+import { prisma } from '../db.js';
+import { highlevelConfigured, upsertContact, createOpportunity, updateOpportunity, ENQUIRY_STAGE_ID } from '../services/highlevel.js';
 
 const router = Router();
 
@@ -21,6 +22,9 @@ const leadSchema = z.object({
   // Free-form notes (e.g. tier interest + GMS used). Surfaced in the team
   // notification email; not pushed to HighLevel as a custom field today.
   notes: z.string().trim().max(500).optional(),
+  // When present, moves the prospect's existing Abandoned-checkout opportunity to
+  // "Enquiry Received & Demo Links sent" instead of creating a fresh opportunity.
+  prospectId: z.string().trim().max(80).optional(),
 });
 
 const PRIMARY_TAG = process.env.GHL_LEAD_TAG || 'website-lead';
@@ -34,7 +38,7 @@ router.post('/public/lead', async (req: Request, res: Response) => {
     return res.status(400).json({ ok: false, error: 'Invalid input', issues: parsed.error.flatten() });
   }
 
-  const { name, companyName, email, phone, source, notes } = parsed.data;
+  const { name, companyName, email, phone, source, notes, prospectId } = parsed.data;
 
   // Always notify the team by email + SMS — gives us a fallback record even
   // if HighLevel is down for any reason.
@@ -44,6 +48,24 @@ router.post('/public/lead', async (req: Request, res: Response) => {
   if (!highlevelConfigured()) {
     console.warn('[LEAD] HighLevel env vars not set — skipping CRM sync.');
     return res.json({ ok: true, syncedToCrm: false });
+  }
+
+  // Prospect path: the opportunity already exists in "Abandoned checkout" (created at the
+  // garage-search step). Enrich the contact and move the opp to the enquiry stage.
+  if (prospectId) {
+    try {
+      const pending = await prisma.pendingSignup.findUnique({ where: { id: prospectId } });
+      if (pending) {
+        await upsertContact({ name, email, phone, companyName, source: source || 'website', tags: [PRIMARY_TAG] });
+        if (pending.ghlOpportunityId && ENQUIRY_STAGE_ID) {
+          await updateOpportunity(pending.ghlOpportunityId, { stageId: ENQUIRY_STAGE_ID });
+        }
+        await prisma.pendingSignup.update({ where: { id: pending.id }, data: { status: 'enquiry', name, email: email.toLowerCase(), contactPhone: phone } });
+        return res.json({ ok: true, syncedToCrm: true, opportunityId: pending.ghlOpportunityId });
+      }
+    } catch (err) {
+      console.error('[LEAD] prospect move failed, falling back to fresh opportunity:', err);
+    }
   }
 
   const contact = await upsertContact({

--- a/backend/src/routes/public-prospect.ts
+++ b/backend/src/routes/public-prospect.ts
@@ -1,0 +1,180 @@
+// Progressive-capture prospect endpoints for the marketing get-started funnel.
+//   POST  /public/prospect       — step 1 (garage chosen): create a PendingSignup + a
+//                                   HighLevel opportunity in "Abandoned checkout".
+//   PATCH /public/prospect/:id    — step 2 (contact details): enrich the contact + prospect.
+// No account is created here — that only happens after sign + card (see webhooks/stripe.ts).
+
+import type { Request, Response } from 'express';
+import { Router } from 'express';
+import { z } from 'zod';
+import { randomBytes } from 'crypto';
+import { prisma } from '../db.js';
+import { fetchPlaceDetails } from '../utils/googlePlaces.js';
+import { highlevelConfigured, upsertContact, updateContact, createOpportunity } from '../services/highlevel.js';
+import type { Prisma } from '@prisma/client';
+
+const router = Router();
+
+const SIGN_LINK_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+const createSchema = z.object({
+  businessName: z.string().trim().min(2).max(200),
+  googlePlaceId: z.string().trim().max(200).optional(),
+  address: z.string().trim().max(500).optional(),
+});
+
+const enrichSchema = z.object({
+  name: z.string().trim().max(120).optional(),
+  email: z.string().trim().email().max(254).optional(),
+  phone: z.string().trim().max(40).optional(),
+  product: z.enum(['assist', 'automate', 'connect', 'multibranch', 'custom']).optional(),
+});
+
+// Give the opportunity a helpful name as we learn more about the prospect.
+function oppName(businessName: string, product?: string | null): string {
+  if (!product) return `${businessName} — signup started`;
+  const label = product === 'assist' ? 'Assist' : product === 'automate' ? 'Automate'
+    : product === 'connect' ? 'Connect' : product === 'multibranch' ? 'Multi-branch' : 'Custom';
+  return `${businessName} — ${label}`;
+}
+
+// Sync a prospect to HighLevel: always upsert (enrich) the contact; create the abandoned-
+// checkout opportunity ONLY if one doesn't exist yet (idempotent — safe to call at every step).
+// Best-effort; returns the resolved { opportunityId, contactId }.
+async function syncProspectToHl(pending: {
+  id: string; businessName: string; name: string | null; email: string | null;
+  phoneNumber: string | null; contactPhone: string | null; websiteUrl: string | null; product: string | null;
+  ghlOpportunityId: string | null; ghlContactId: string | null;
+}): Promise<{ opportunityId: string | null; contactId: string | null }> {
+  if (!highlevelConfigured()) {
+    return { opportunityId: pending.ghlOpportunityId, contactId: pending.ghlContactId };
+  }
+
+  const realPhone = pending.contactPhone || pending.phoneNumber || undefined;
+  const realEmail = pending.email || undefined;
+  let contactId = pending.ghlContactId;
+
+  if (contactId) {
+    // Enrich the EXISTING contact by id (replaces any placeholder) — never creates a duplicate.
+    await updateContact(contactId, {
+      name: pending.name || pending.businessName,
+      email: realEmail,
+      phone: realPhone,
+      website: pending.websiteUrl ?? undefined,
+    });
+  } else {
+    // First contact for this prospect. HL needs a phone OR email; if we have neither yet (no
+    // Google phone, no email until the next step), use a UNIQUE placeholder email so the
+    // opportunity is still created from just the business name. It's overwritten on enrich.
+    const placeholderEmail = !realEmail && !realPhone ? `prospect-${pending.id}@pending.receptionmate.co.uk` : undefined;
+    const contact = await upsertContact({
+      name: pending.name || pending.businessName,
+      email: realEmail || placeholderEmail,
+      phone: realPhone,
+      companyName: pending.businessName,
+      website: pending.websiteUrl ?? undefined,
+      source: 'website-getstarted',
+      tags: ['website-signup', 'abandoned-checkout'],
+    });
+    contactId = contact.contactId;
+  }
+
+  let opportunityId = pending.ghlOpportunityId;
+  if (!opportunityId && contactId) {
+    const opp = await createOpportunity({
+      contactId,
+      name: oppName(pending.businessName, pending.product),
+      kind: 'abandoned',
+    });
+    opportunityId = opp.id;
+  }
+  return { opportunityId, contactId };
+}
+
+// POST /api/public/prospect — step 1
+router.post('/public/prospect', async (req: Request, res: Response) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ ok: false, error: 'invalid_request' });
+  const { businessName, googlePlaceId, address } = parsed.data;
+
+  try {
+    const place = googlePlaceId ? await fetchPlaceDetails(googlePlaceId) : null;
+    const signToken = randomBytes(32).toString('base64url');
+    const pending = await prisma.pendingSignup.create({
+      data: {
+        businessName,
+        email: '', // filled at the enrich step
+        googlePlaceId: googlePlaceId ?? null,
+        branchAddress: place?.address || address || null,
+        phoneNumber: place?.phone || null,
+        websiteUrl: place?.website || null,
+        weeklyOpeningHours: place?.weeklyOpeningHours
+          ? (place.weeklyOpeningHours as Prisma.InputJsonValue)
+          : undefined,
+        signToken,
+        status: 'prospect',
+        expiresAt: new Date(Date.now() + SIGN_LINK_TTL_MS),
+      },
+    });
+
+    // Fire the abandoned-checkout opportunity (best-effort; won't block the response).
+    void syncProspectToHl(pending)
+      .then(({ opportunityId, contactId }) => {
+        if (opportunityId || contactId) {
+          return prisma.pendingSignup.update({
+            where: { id: pending.id },
+            data: { ghlOpportunityId: opportunityId, ghlContactId: contactId },
+          });
+        }
+      })
+      .catch((e) => console.error('[PROSPECT] HL abandoned opp failed:', e));
+
+    return res.json({ ok: true, prospectId: pending.id, signToken });
+  } catch (err) {
+    console.error('[PROSPECT] create failed:', err);
+    return res.status(500).json({ ok: false, error: 'server_error' });
+  }
+});
+
+// PATCH /api/public/prospect/:id — step 2 (enrich with contact details)
+router.patch('/public/prospect/:id', async (req: Request, res: Response) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  const parsed = enrichSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ ok: false, error: 'invalid_request' });
+
+  try {
+    const pending = await prisma.pendingSignup.findUnique({ where: { id: req.params.id } });
+    if (!pending || pending.status === 'completed') {
+      return res.status(404).json({ ok: false, error: 'not_found' });
+    }
+    const updated = await prisma.pendingSignup.update({
+      where: { id: pending.id },
+      data: {
+        name: parsed.data.name ?? pending.name,
+        email: parsed.data.email ? parsed.data.email.toLowerCase() : pending.email,
+        contactPhone: parsed.data.phone ?? pending.contactPhone,
+        product: parsed.data.product ?? pending.product,
+      },
+    });
+
+    // Enrich the HL contact + create the opp now if it wasn't made at step 1 (no id then).
+    void syncProspectToHl(updated)
+      .then(({ opportunityId, contactId }) => {
+        if (opportunityId !== updated.ghlOpportunityId || contactId !== updated.ghlContactId) {
+          return prisma.pendingSignup.update({
+            where: { id: updated.id },
+            data: { ghlOpportunityId: opportunityId, ghlContactId: contactId },
+          });
+        }
+      })
+      .catch((e) => console.error('[PROSPECT] HL enrich failed:', e));
+
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error('[PROSPECT] enrich failed:', err);
+    return res.status(500).json({ ok: false, error: 'server_error' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/public-signup.ts
+++ b/backend/src/routes/public-signup.ts
@@ -5,9 +5,8 @@ import bcrypt from 'bcryptjs';
 import { randomBytes } from 'crypto';
 import { prisma } from '../db.js';
 import { sendEmail } from '../utils/email.js';
-import { sendOpsSms } from '../utils/opsAlerts.js';
 import { TEMPLATE_VERSION } from '../services/agreementTemplate.js';
-import { pushSignupToHighlevel } from '../services/highlevel.js';
+import { pushSignupToHighlevel, updateContact } from '../services/highlevel.js';
 import { ensureAdminAccessToGarage } from './admin.js';
 import { fetchPlaceDetails } from '../utils/googlePlaces.js';
 import { industryDefaultFaqs, generateFaqsFromWebsite } from '../utils/faqGenerator.js';
@@ -16,10 +15,10 @@ import type { Prisma } from '@prisma/client';
 
 const router = Router();
 
-// Public marketing-site signup. Creates a new Business + Garage + AgentConfiguration + User
-// with Assist defaults. The downstream activation friction (password reset, setup wizard,
-// Direct Debit mandate) acts as the real anti-abuse mechanism — no resources are provisioned
-// until the customer completes those steps.
+// Assist self-serve signup. IMPORTANT: no real account (Business/Garage/User/Agreement) is
+// created here. Submitting details only creates/updates a PendingSignup and points the customer
+// at the agreement. The account is created ONLY after they sign AND confirm a card — from the
+// Stripe setup_intent.succeeded webhook, via createAccountFromPending() below.
 const ASSIST_DEFAULTS = {
   subscriptionCostGbp: 200,
   includedMinutes: 400,
@@ -28,41 +27,159 @@ const ASSIST_DEFAULTS = {
 };
 
 const PORTAL_URL = process.env.PORTAL_URL || 'https://portal.receptionmate.co.uk';
-
-const publicSignupSchema = z.object({
-  businessName: z.string().trim().min(2).max(200),
-  email: z.string().trim().email().max(254),
-  address: z.string().trim().max(500).optional(),
-  googlePlaceId: z.string().trim().max(200).optional(),
-  // Customer's personal name. Optional for back-compat; new marketing-site
-  // submissions always include it so we can populate HighLevel's contact name.
-  name: z.string().trim().min(2).max(120).optional(),
-});
-
-// Same fixed temp password for every public signup. `mustChangePassword=true`
-// forces a change on first login, so this is just a one-time bootstrap secret
-// the welcome email reveals after the user has signed their agreement.
 const PUBLIC_SIGNUP_TEMP_PASSWORD = 'Nomoremissedcalls';
-
-// Magic-link sign tokens live for 14 days — long enough that customers don't
-// have to chase a re-send, short enough that abandoned signups expire.
 const SIGN_LINK_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 
 function escapeForEmail(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
+const publicSignupSchema = z.object({
+  businessName: z.string().trim().min(2).max(200),
+  email: z.string().trim().email().max(254),
+  address: z.string().trim().max(500).optional(),
+  googlePlaceId: z.string().trim().max(200).optional(),
+  name: z.string().trim().min(2).max(120).optional(),
+  // Contact phone captured on the details step (name / email / number).
+  phone: z.string().trim().max(40).optional(),
+  // When present, links to the prospect row created at the garage-search step (step 1).
+  prospectId: z.string().trim().max(80).optional(),
+});
+
+/**
+ * Create the real Assist account from a completed (signed + carded) PendingSignup.
+ * Idempotent — safe to call more than once. Called ONLY from the Stripe
+ * setup_intent.succeeded webhook, never before the card is confirmed.
+ */
+export async function createAccountFromPending(
+  pendingId: string,
+): Promise<{ garageId: string; garageName: string; userEmail: string } | null> {
+  const pending = await prisma.pendingSignup.findUnique({ where: { id: pendingId } });
+  if (!pending) return null;
+  if (pending.createdGarageId) {
+    const g = await prisma.garage.findUnique({ where: { id: pending.createdGarageId }, select: { id: true, name: true } });
+    return g ? { garageId: g.id, garageName: g.name, userEmail: pending.email } : null;
+  }
+
+  const businessName = pending.businessName;
+  const normalizedEmail = pending.email.toLowerCase();
+  const existing = await prisma.user.findUnique({ where: { email: normalizedEmail } });
+  if (existing) {
+    console.error('[PUBLIC_SIGNUP] createAccountFromPending: email already has an account:', normalizedEmail);
+    return null;
+  }
+
+  const greetingLine = `[timeofday], ${businessName}, Leah speaking, how can I help?`;
+  const seededFaqs = industryDefaultFaqs(businessName);
+
+  const business = await prisma.business.create({ data: { name: businessName } });
+  const garage = await prisma.garage.create({
+    data: {
+      name: businessName,
+      businessId: business.id,
+      subscriptionCostGbp: ASSIST_DEFAULTS.subscriptionCostGbp,
+      includedMinutes: ASSIST_DEFAULTS.includedMinutes,
+      costPerMinuteGbp: ASSIST_DEFAULTS.costPerMinuteGbp,
+      vatRate: ASSIST_DEFAULTS.vatRate,
+      stripeCustomerId: pending.stripeCustomerId,
+      stripeSubscriptionId: pending.stripeSubscriptionId,
+      trialEndsAt: pending.trialEndsAt,
+      ghlOpportunityId: pending.ghlOpportunityId,
+    },
+  });
+  await prisma.agentConfiguration.create({
+    data: {
+      garageId: garage.id,
+      branchName: businessName,
+      branchAddress: pending.branchAddress,
+      phoneNumber: pending.phoneNumber,
+      websiteUrl: pending.websiteUrl,
+      emailAddress: normalizedEmail,
+      ...(pending.weeklyOpeningHours ? { weeklyOpeningHours: pending.weeklyOpeningHours as Prisma.InputJsonValue } : {}),
+      greetingLine,
+      faqs: seededFaqs as unknown as Prisma.InputJsonValue,
+      tonePreference: 'standard',
+      responseSpeed: 'normal',
+      interruptionSensitivity: 0.5,
+      allowFastFitOnly: false,
+      integrationProvider: 'none',
+      agentType: 'assist',
+      agentScript: 'Assist-agent',
+    },
+  });
+  const passwordHash = await bcrypt.hash(PUBLIC_SIGNUP_TEMP_PASSWORD, 10);
+  const user = await prisma.user.create({
+    data: {
+      email: normalizedEmail,
+      passwordHash,
+      mustChangePassword: true,
+      mustSetupPayment: false, // paid via Stripe card — skip the GoCardless DD gate
+      garageAccessIds: [garage.id],
+      role: 'MANAGER',
+      branchRoles: { [garage.id]: 'MANAGER' },
+    },
+  });
+  await prisma.agreement.create({
+    data: {
+      type: 'saas',
+      version: pending.agreementVersion || TEMPLATE_VERSION,
+      status: 'signed',
+      userId: user.id,
+      businessId: business.id,
+      clientName: businessName,
+      setupFeeGbp: 0,
+      licenceFeeGbp: ASSIST_DEFAULTS.subscriptionCostGbp,
+      centresCount: 1,
+      licences: ['assist'],
+      goLiveDate: new Date(),
+      signedAt: pending.signedAt ?? new Date(),
+      signedByName: pending.signedByName,
+      signedByEmail: normalizedEmail,
+      signedFromIp: pending.signedFromIp,
+      signedUserAgent: pending.signedUserAgent,
+      signatureImage: pending.signatureImage,
+      templateSnapshot: pending.templateSnapshot || '',
+    },
+  });
+
+  await ensureAdminAccessToGarage(garage.id).catch((err) =>
+    console.error('[PUBLIC_SIGNUP] ensureAdminAccessToGarage failed:', err),
+  );
+  await prisma.pendingSignup.update({
+    where: { id: pending.id },
+    data: { status: 'completed', createdGarageId: garage.id },
+  });
+
+  // Background: upgrade the seeded FAQs from the garage's website + ingest into the KB.
+  if (pending.websiteUrl) {
+    const site = pending.websiteUrl;
+    void (async () => {
+      try {
+        const aiFaqs = await generateFaqsFromWebsite(site, businessName);
+        if (aiFaqs.length >= 3) {
+          await prisma.agentConfiguration.update({
+            where: { garageId: garage.id },
+            data: { faqs: aiFaqs as unknown as Prisma.InputJsonValue },
+          });
+        }
+      } catch (err) {
+        console.error('[PUBLIC_SIGNUP] background FAQ generation failed:', err);
+      }
+      await autoIngestWebsiteKnowledge(garage.id, site).catch(() => {});
+    })();
+  }
+
+  console.log(`[PUBLIC_SIGNUP] account created from pending=${pending.id} → garage=${garage.id} (${businessName})`);
+  return { garageId: garage.id, garageName: businessName, userEmail: normalizedEmail };
+}
+
 router.post('/public-signup', async (req: Request, res: Response) => {
   const parsed = publicSignupSchema.safeParse(req.body);
   if (!parsed.success) {
-    return res.status(400).json({
-      success: false,
-      error: 'invalid_request',
-      details: parsed.error.flatten(),
-    });
+    return res.status(400).json({ success: false, error: 'invalid_request', details: parsed.error.flatten() });
   }
 
-  const { businessName, email, address, googlePlaceId, name } = parsed.data;
+  const { businessName, email, address, googlePlaceId, name, phone, prospectId } = parsed.data;
   const normalizedEmail = email.toLowerCase();
 
   try {
@@ -77,238 +194,107 @@ router.post('/public-signup', async (req: Request, res: Response) => {
       });
     }
 
-    // 0. Enrich from the Google Places link. The marketing-site autocomplete only
-    //    gives us name + address; the Place Details lookup adds phone, website and
-    //    opening hours. Fast (6s timeout) and fully non-fatal — signup proceeds even
-    //    if Google is slow or the key lacks a scope.
-    const place = await fetchPlaceDetails(googlePlaceId);
-    const branchAddress = place?.address || address || null;
-    const phoneNumber = place?.phone || null;
-    const websiteUrl = place?.website || null;
-    const weeklyOpeningHours = place?.weeklyOpeningHours;
-    // Default greeting: "Good morning, {garage}, Leah speaking, how can I help?"
-    // ([timeofday] is expanded by the agent at runtime). Fully editable in the portal.
-    const greetingLine = `[timeofday], ${businessName}, Leah speaking, how can I help?`;
-    // Seed industry-standard FAQs immediately; a background job upgrades them from the
-    // garage's website (if any) just below.
-    const seededFaqs = industryDefaultFaqs(businessName);
+    // Reuse the prospect row from step 1 if present; else create a fresh pending (direct signup).
+    let pending =
+      prospectId ? await prisma.pendingSignup.findUnique({ where: { id: prospectId } }) : null;
 
-    // 1. Business
-    const business = await prisma.business.create({
-      data: { name: businessName },
-    });
-
-    // 2. Garage (with Assist pricing baked in so it's immediately billable
-    //    once the user completes Direct Debit setup)
-    const garage = await prisma.garage.create({
-      data: {
-        name: businessName,
-        businessId: business.id,
-        subscriptionCostGbp: ASSIST_DEFAULTS.subscriptionCostGbp,
-        includedMinutes: ASSIST_DEFAULTS.includedMinutes,
-        costPerMinuteGbp: ASSIST_DEFAULTS.costPerMinuteGbp,
-        vatRate: ASSIST_DEFAULTS.vatRate,
-      },
-    });
-
-    // 3. AgentConfiguration — defaults to Assist mode. The user can switch
-    //    to Automate later via the portal once they've integrated their booking system.
-    await prisma.agentConfiguration.create({
-      data: {
-        garageId: garage.id,
-        branchName: businessName,
-        branchAddress,
-        phoneNumber,
-        websiteUrl,
-        emailAddress: normalizedEmail,
-        ...(weeklyOpeningHours ? { weeklyOpeningHours: weeklyOpeningHours as Prisma.InputJsonValue } : {}),
-        greetingLine,
-        faqs: seededFaqs as unknown as Prisma.InputJsonValue,
-        tonePreference: 'standard',
-        responseSpeed: 'normal',
-        interruptionSensitivity: 0.5,
-        allowFastFitOnly: false,
-        integrationProvider: 'none',
-        agentType: 'assist',
-        // Self-serve sign-ups always go to the Assist worker on the newer
-        // LiveKit project (labelled "RMB-Assist" in the portal). Saves the
-        // ops team a trip into Agent Configurations -> Routing.
-        agentScript: 'Assist-agent',
-      },
-    });
-
-    // Background: upgrade the seeded FAQs from the garage's website (scrape + AI).
-    // Fire-and-forget so signup stays fast; writes straight to Postgres, which the
-    // setup wizard reads when the customer reviews their config.
-    if (websiteUrl) {
-      void (async () => {
-        try {
-          const aiFaqs = await generateFaqsFromWebsite(websiteUrl!, businessName);
-          if (aiFaqs.length >= 3) {
-            await prisma.agentConfiguration.update({
-              where: { garageId: garage.id },
-              data: { faqs: aiFaqs as unknown as Prisma.InputJsonValue },
-            });
-            console.log(`[PUBLIC_SIGNUP] FAQs upgraded from website for garage=${garage.id} (${aiFaqs.length})`);
-          }
-        } catch (err) {
-          console.error('[PUBLIC_SIGNUP] background FAQ generation failed:', err);
+    if (pending && pending.status !== 'completed') {
+      pending = await prisma.pendingSignup.update({
+        where: { id: pending.id },
+        data: { name: name ?? pending.name, email: normalizedEmail, contactPhone: phone ?? pending.contactPhone, product: 'assist', status: 'pending' },
+      });
+      // Enrich the existing Abandoned-checkout HL contact with the real name + email + phone
+      // (replaces the placeholder from the garage-search step) — updates by id, no duplicate.
+      if (pending.ghlContactId) {
+        void updateContact(pending.ghlContactId, { name: name || businessName, email: normalizedEmail, phone: phone || undefined })
+          .catch((e) => console.error('[PUBLIC_SIGNUP] HL contact enrich failed:', e));
+      }
+    } else {
+      const place = googlePlaceId ? await fetchPlaceDetails(googlePlaceId) : null;
+      const signToken = randomBytes(32).toString('base64url');
+      pending = await prisma.pendingSignup.create({
+        data: {
+          businessName,
+          email: normalizedEmail,
+          name: name ?? null,
+          googlePlaceId: googlePlaceId ?? null,
+          branchAddress: place?.address || address || null,
+          phoneNumber: place?.phone || null,
+          websiteUrl: place?.website || null,
+          ...(place?.weeklyOpeningHours ? { weeklyOpeningHours: place.weeklyOpeningHours as Prisma.InputJsonValue } : {}),
+          signToken,
+          status: 'pending',
+          product: 'assist',
+          expiresAt: new Date(Date.now() + SIGN_LINK_TTL_MS),
+        },
+      });
+      // Abandoned-checkout opportunity for direct signups that skipped the prospect step.
+      const p = pending;
+      void pushSignupToHighlevel({
+        name: name || businessName,
+        email: normalizedEmail,
+        phone: place?.phone ?? undefined,
+        companyName: businessName,
+        website: place?.website ?? undefined,
+        source: 'website-getstarted-assist',
+        tags: ['website-signup', 'abandoned-checkout', 'assist'],
+        opportunityName: `${businessName} — Assist`,
+        kind: 'abandoned',
+      }).then((r) => {
+        if (r.opportunityId || r.contactId) {
+          return prisma.pendingSignup.update({ where: { id: p.id }, data: { ghlOpportunityId: r.opportunityId, ghlContactId: r.contactId } });
         }
-        // Also ingest the website into the knowledge base so the agent can answer from it via RAG
-        // (separate from the distilled FAQs above). Best-effort, fire-and-forget.
-        await autoIngestWebsiteKnowledge(garage.id, websiteUrl!);
-      })();
+      }).catch((e) => console.error('[PUBLIC_SIGNUP] HL abandoned opp failed:', e));
     }
 
-    // 3a. Grant RECEPTIONMATE_STAFF access so the team can see the new garage
-    //     in their admin views — same call the admin quick-onboard makes.
-    await ensureAdminAccessToGarage(garage.id).catch((err) =>
-      console.error('[PUBLIC_SIGNUP] ensureAdminAccessToGarage failed:', err),
-    );
+    const signUrl = `${PORTAL_URL}/agreement/sign?token=${encodeURIComponent(pending.signToken)}`;
 
-    // 3b. NOTE: Twilio number purchase + SIP provisioning used to live here.
-    //     They've been moved to the Stripe webhook handler so we only spend
-    //     money on a number after the customer has actually paid for their
-    //     first month. See `routes/webhooks/stripe.ts`.
-
-    // 4. User account. Password is the well-known temp value; `mustChangePassword`
-    //    forces them to change it on first login. The welcome email that reveals
-    //    this password is held back until the user has signed their agreement.
-    const passwordHash = await bcrypt.hash(PUBLIC_SIGNUP_TEMP_PASSWORD, 10);
-    const user = await prisma.user.create({
-      data: {
-        email: normalizedEmail,
-        passwordHash,
-        mustChangePassword: true,
-        mustSetupPayment: true,
-        garageAccessIds: [garage.id],
-        role: 'MANAGER',
-        branchRoles: { [garage.id]: 'MANAGER' },
-      },
-    });
-
-    // 4a. Draft service agreement on Assist defaults. The user signs it via
-    //     the magic-link below — only after signing do they get login details.
-    //     Assist is instant-live so we set goLiveDate to today; Automate /
-    //     Connect signups (when we wire those) will use null until scoped.
-    const agreement = await prisma.agreement.create({
-      data: {
-        type: 'saas',
-        version: TEMPLATE_VERSION,
-        status: 'sent',
-        userId: user.id,
-        businessId: business.id,
-        clientName: businessName,
-        setupFeeGbp: 0,
-        licenceFeeGbp: ASSIST_DEFAULTS.subscriptionCostGbp,
-        centresCount: 1,
-        licences: ['assist'],
-        goLiveDate: new Date(),
-        templateSnapshot: '',
-      },
-    });
-
-    // 4b. Magic-link sign token — single-use, expires in 14 days.
-    const token = randomBytes(32).toString('base64url');
-    await prisma.signLinkToken.create({
-      data: {
-        token,
-        userId: user.id,
-        agreementId: agreement.id,
-        purpose: 'sign_agreement',
-        expiresAt: new Date(Date.now() + SIGN_LINK_TTL_MS),
-      },
-    });
-    const signUrl = `${PORTAL_URL}/agreement/sign?token=${encodeURIComponent(token)}`;
-
-    // 5. Send the "Review and sign" email. The welcome email (with login
-    //    details) is sent later, from the agreement-sign endpoint, once the
-    //    customer has actually signed.
-    // Backup email — only matters if the user closes the tab before signing.
-    // The marketing site redirects them straight to the sign page so the
-    // common path doesn't touch their inbox at all.
+    // Backup "review & sign" email — the marketing site redirects straight to signUrl, so the
+    // common path doesn't touch the inbox. No account details are revealed until they've paid.
     const subject = 'Finish setting up your ReceptionMate account';
     const html = `
       <div style="font-family:Inter,system-ui,sans-serif;max-width:560px;margin:0 auto;color:#0f172a;">
         <h2 style="color:#3426cf;margin:0 0 12px;">Welcome to ReceptionMate</h2>
         <p>Hi ${escapeForEmail(businessName)},</p>
-        <p>Thanks for signing up. If you closed the tab before finishing, you can review and sign your service agreement using the button below — once signed, we'll email your portal login details straight away.</p>
+        <p>Thanks for getting started. To finish, review and sign your service agreement and add your card to start your 14-day free trial — you won't be charged today.</p>
         <p style="text-align:center;margin:28px 0;">
-          <a href="${signUrl}" style="display:inline-block;background:#3426cf;color:#fff;text-decoration:none;padding:12px 22px;border-radius:10px;font-weight:600;">Review and sign</a>
+          <a href="${signUrl}" style="display:inline-block;background:#3426cf;color:#fff;text-decoration:none;padding:12px 22px;border-radius:10px;font-weight:600;">Review, sign &amp; start free trial</a>
         </p>
-        <p style="color:#94a3b8;font-size:13px;">This link is valid for 14 days. If you have any questions, just reply to this email.</p>
-        <p style="margin-top:32px;color:#64748b;font-size:13px;">— The ReceptionMate team</p>
-      </div>
-    `;
-    const text = `Welcome to ReceptionMate!\n\nIf you closed the tab before finishing, you can review and sign your service agreement here:\n${signUrl}\n\nOnce signed, we'll email your portal login details straight away.\n\nThis link is valid for 14 days.\n\n— The ReceptionMate team`;
-
+        <p style="color:#94a3b8;font-size:13px;">This link is valid for 14 days.</p>
+      </div>`;
+    const text = `Welcome to ReceptionMate!\n\nReview and sign your agreement and add your card to start your 14-day free trial (no charge today):\n${signUrl}\n\nThis link is valid for 14 days.`;
     await sendEmail({ to: [normalizedEmail], subject, html, text }).catch((error) => {
-      console.error('[PUBLIC_SIGNUP] sign-agreement email failed:', error);
+      console.error('[PUBLIC_SIGNUP] sign email failed:', error);
     });
 
-    // 6. HighLevel push — contact + opportunity in the "Free trial live" stage of
-    //    the "Onboarding Newest" pipeline. Store the opportunity id so the Stripe
-    //    webhook can promote it to "Live and £££" when the 14-day trial converts.
-    void pushSignupToHighlevel({
-      name: name || businessName,
-      email: normalizedEmail,
-      phone: phoneNumber ?? undefined,
-      companyName: businessName,
-      website: websiteUrl ?? undefined,
-      source: 'website-getstarted-assist',
-      tags: ['website-signup', 'assist', 'trial'],
-      opportunityName: `${businessName} — Assist 14-day trial (£${ASSIST_DEFAULTS.subscriptionCostGbp}/mo per branch)`,
-      monetaryValueGbp: ASSIST_DEFAULTS.subscriptionCostGbp,
-      monthlyCostPerBranchGbp: ASSIST_DEFAULTS.subscriptionCostGbp,
-      packageName: 'Assist',
-      kind: 'trial',
-    }).then((r) => {
-      if (r.opportunityId) {
-        prisma.garage
-          .update({ where: { id: garage.id }, data: { ghlOpportunityId: r.opportunityId } })
-          .catch((e) => console.error('[PUBLIC_SIGNUP] failed to store ghlOpportunityId:', e));
-      }
-    });
-
-    console.log(`[PUBLIC_SIGNUP] created account: ${normalizedEmail} → ${businessName} (garage=${garage.id}, agreement=${agreement.id})`);
-
-    // Ops alert — email + SMS to the team so a new Assist trial signup is impossible to miss.
-    {
-      const details = [
-        `Business: ${businessName}`,
-        `Email: ${normalizedEmail}`,
-        phoneNumber ? `Phone: ${phoneNumber}` : null,
-        websiteUrl ? `Website: ${websiteUrl}` : null,
-      ].filter(Boolean) as string[];
-      void sendEmail({
-        to: ['hello@receptionmate.co.uk'],
-        subject: `New Assist trial signup — ${businessName}`,
-        html:
-          `<div style="font-family:Inter,system-ui,sans-serif;max-width:560px;color:#0f172a;">` +
-          `<h2 style="color:#3426cf;margin:0 0 12px;">New Assist 14-day trial signup 🎉</h2>` +
-          details.map((d) => `<p style="margin:4px 0;">${escapeForEmail(d)}</p>`).join('') +
-          `<p style="margin-top:16px;color:#64748b;font-size:12px;">Opportunity created in HighLevel (Free trial live).</p></div>`,
-        text: `New Assist 14-day trial signup\n\n${details.join('\n')}`,
-      }).catch((e) => console.error('[PUBLIC_SIGNUP] ops signup email failed:', e));
-      void sendOpsSms(
-        `New Assist trial signup 🎉\n${businessName}\n${normalizedEmail}${phoneNumber ? ` · ${phoneNumber}` : ''}`,
-      );
-    }
-
-    return res.status(201).json({
-      success: true,
-      // The marketing site redirects the user straight to this URL so they
-      // sign in-browser. The email above is a backup if they close the tab.
-      signUrl,
-      businessName,
-    });
+    console.log(`[PUBLIC_SIGNUP] pending ready to sign: ${normalizedEmail} → ${businessName} (pending=${pending.id})`);
+    return res.status(201).json({ success: true, signUrl, businessName });
   } catch (error) {
     console.error('[PUBLIC_SIGNUP] failed:', error);
-    return res.status(500).json({
-      success: false,
-      error: 'server_error',
-      message: 'Something went wrong creating your account. Email hello@receptionmate.co.uk and we\'ll sort it.',
+    return res.status(500).json({ success: false, error: 'server_error' });
+  }
+});
+
+// POST /api/public/signup-complete — called by the card form the instant Stripe confirms the
+// card. Creates the account from the pending row (idempotent) and returns a one-time set-password
+// token so the customer lands on the "Choose a password" page and is auto-logged-in on submit.
+const completeSchema = z.object({ pendingSignupId: z.string().trim().min(1).max(80) });
+router.post('/public/signup-complete', async (req: Request, res: Response) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  const parsed = completeSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ ok: false, error: 'invalid_request' });
+  try {
+    const created = await createAccountFromPending(parsed.data.pendingSignupId);
+    if (!created) return res.status(409).json({ ok: false, error: 'could_not_create' });
+    const resetToken = randomBytes(32).toString('hex');
+    await prisma.user.update({
+      where: { email: created.userEmail },
+      data: { resetToken, resetTokenExpiry: new Date(Date.now() + 60 * 60 * 1000) },
     });
+    return res.json({ ok: true, resetToken });
+  } catch (err) {
+    console.error('[PUBLIC_SIGNUP] signup-complete failed:', err);
+    return res.status(500).json({ ok: false, error: 'server_error' });
   }
 });
 

--- a/backend/src/routes/webhooks/stripe.ts
+++ b/backend/src/routes/webhooks/stripe.ts
@@ -19,7 +19,9 @@ import { ARREARS_GRACE_DAYS } from '../../utils/arrears.js';
 import { getStripeClient, STRIPE_TRIAL_DAYS } from '../../services/stripe.js';
 import { purchaseRandomTwilioNumber } from '../onboarding.js';
 import { sendAgentConfigWebhook } from '../config.js';
-import { updateOpportunity, LIVE_STAGE_ID } from '../../services/highlevel.js';
+import { updateOpportunity, LIVE_STAGE_ID, TRIAL_LIVE_STAGE_ID } from '../../services/highlevel.js';
+import { createAccountFromPending } from '../public-signup.js';
+import { sendOpsSms } from '../../utils/opsAlerts.js';
 
 const router = Router();
 
@@ -114,6 +116,37 @@ async function provisionGarageAccount(garage: { id: string; name: string }, user
 async function handleSetupIntentSucceeded(si: Stripe.SetupIntent): Promise<void> {
   const customerId = typeof si.customer === 'string' ? si.customer : si.customer?.id ?? null;
   if (!customerId) return;
+
+  // Deferred-account flow: the card belongs to a PendingSignup, not a garage yet. Create the
+  // account now (idempotent — the /public/signup-complete call may have already done it),
+  // provision, move the HL opportunity to "Free trial live", and alert the team.
+  const pending = await prisma.pendingSignup.findFirst({
+    where: { stripeCustomerId: customerId },
+    orderBy: { createdAt: 'desc' },
+  });
+  if (pending) {
+    const created = await createAccountFromPending(pending.id);
+    if (created) {
+      const g = await prisma.garage.findUnique({ where: { id: created.garageId }, select: { twilioNumber: true } });
+      if (!g?.twilioNumber) {
+        await provisionGarageAccount({ id: created.garageId, name: created.garageName }, created.userEmail);
+      }
+      if (pending.ghlOpportunityId && TRIAL_LIVE_STAGE_ID) {
+        void updateOpportunity(pending.ghlOpportunityId, { stageId: TRIAL_LIVE_STAGE_ID, monetaryValueGbp: 200 })
+          .then((ok) => console.log(`[STRIPE_WEBHOOK] HL opp ${pending.ghlOpportunityId} → Free trial live (${ok ? 'ok' : 'failed'})`));
+      }
+      // Ops alert — a real, carded trial signup.
+      void sendEmail({
+        to: ['hello@receptionmate.co.uk'],
+        subject: `New Assist trial signup — ${created.garageName}`,
+        text: `New Assist 14-day trial signup (card confirmed).\n\nBusiness: ${created.garageName}\nEmail: ${created.userEmail}`,
+        html: `<p>New Assist 14-day trial signup 🎉 (card confirmed)</p><p>Business: <strong>${created.garageName}</strong><br/>Email: ${created.userEmail}</p>`,
+      }).catch(() => {});
+      void sendOpsSms(`New Assist trial signup 🎉\n${created.garageName}\n${created.userEmail}`);
+    }
+    return;
+  }
+
   const garage = await prisma.garage.findFirst({
     where: { stripeCustomerId: customerId },
     select: { id: true, name: true, twilioNumber: true },

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -39,10 +39,12 @@ import publicStatsRouter from './routes/public-stats.js';
 import publicLeadRouter from './routes/public-lead.js';
 import agreementsRouter from './routes/agreements.js';
 import supportRouter from './routes/support.js';
+import deviceTokensRouter from './routes/deviceTokens.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { initializeScheduledReports } from './utils/scheduler.js';
 import { startArrearsSweep } from './utils/arrears.js';
 import billingStatusRouter from './routes/billing-status.js';
+import publicProspectRouter from './routes/public-prospect.js';
 
 const app = express();
 
@@ -62,7 +64,7 @@ app.use(helmet());
 const PUBLIC_CORS_PATHS = ['/api/public', '/api/public-signup', '/api/livekit'];
 app.use(
   PUBLIC_CORS_PATHS,
-  cors({ origin: '*', methods: ['GET', 'POST', 'OPTIONS'], allowedHeaders: ['Content-Type'], maxAge: 86400 }),
+  cors({ origin: '*', methods: ['GET', 'POST', 'PATCH', 'OPTIONS'], allowedHeaders: ['Content-Type'], maxAge: 86400 }),
 );
 
 // Strict CORS for the authenticated portal API. We SKIP /api/public so
@@ -118,6 +120,7 @@ app.use('/api', billingRouter);
 app.use('/api', billingActivationRouter);
 app.use('/api/customer/billing', customerBillingRouter);
 app.use('/api', billingStatusRouter);
+app.use('/api', publicProspectRouter);
 app.use('/api', socialConnectionsRouter);
 app.use('/api', oauthRouter);
 app.use('/api', smsRouter);
@@ -133,6 +136,7 @@ app.use('/api', publicLeadRouter);
 app.use('/api', livekitDemoRouter);
 app.use('/api', agreementsRouter);
 app.use('/api', supportRouter);
+app.use('/api', deviceTokensRouter);
 app.use('/api', templatesRouter);
 app.use('/api/webhooks', metaWhatsappWebhook);
 app.use('/api/webhooks', metaFacebookWebhook);

--- a/backend/src/services/highlevel.ts
+++ b/backend/src/services/highlevel.ts
@@ -21,8 +21,16 @@ const PIPELINE_ID     = process.env.GHL_PIPELINE_ID     ?? '';
 const SIGNUP_STAGE_ID = process.env.GHL_SIGNUP_STAGE_ID ?? '';
 const LEAD_STAGE_ID   = process.env.GHL_LEAD_STAGE_ID   ?? '';
 const TRIAL_STAGE_ID  = process.env.GHL_TRIAL_STAGE_ID  ?? '';
+// New self-serve signups land here on details-submit (before they sign + pay), then move
+// to "Free trial live" once the account is created. Defaults to the live stage id.
+const ABANDONED_STAGE_ID = process.env.GHL_ABANDONED_STAGE_ID ?? '81307e40-9210-47e4-9898-7f1a18ce8ee7';
 // The "Live and £££" stage an opportunity is promoted to once the trial converts.
 export const LIVE_STAGE_ID = SIGNUP_STAGE_ID;
+// The "Free trial live" stage a signup moves to once it becomes a real trial account.
+export const TRIAL_LIVE_STAGE_ID = TRIAL_STAGE_ID;
+// The "Enquiry Received & Demo Links sent" stage a non-Assist lead moves to (it passes
+// through Abandoned checkout first, per the get-started flow).
+export const ENQUIRY_STAGE_ID = LEAD_STAGE_ID;
 
 const HEADERS = {
   Authorization: `Bearer ${GHL_PIT}`,
@@ -41,7 +49,9 @@ function pipelineConfigured(): boolean {
 
 export interface UpsertContactArgs {
   name: string;
-  email: string;
+  // Email OR phone must be present — HL needs at least one identifier. At the garage-search
+  // step of the funnel we only have the garage's Google phone (no user email yet).
+  email?: string;
   phone?: string;
   companyName: string;
   website?: string;
@@ -66,11 +76,11 @@ export async function upsertContact(args: UpsertContactArgs): Promise<ContactRes
     firstName,
     lastName,
     name: args.name,
-    email: args.email,
     companyName: args.companyName,
     source: args.source || 'website',
     tags: args.tags ?? ['website-lead'],
   };
+  if (args.email) body.email = args.email;
   if (args.phone) body.phone = args.phone;
   if (args.website) body.website = args.website;
 
@@ -93,7 +103,42 @@ export async function upsertContact(args: UpsertContactArgs): Promise<ContactRes
   }
 }
 
-export type OpportunityKind = 'signup' | 'lead' | 'trial';
+// Update an existing contact by id (PUT) — used to replace a placeholder identifier with the
+// real name/email/phone as a prospect progresses, without creating a duplicate. Tolerant.
+export async function updateContact(
+  contactId: string,
+  fields: { name?: string; email?: string; phone?: string; website?: string },
+): Promise<boolean> {
+  if (!highlevelConfigured() || !contactId) return false;
+  const body: Record<string, unknown> = {};
+  if (fields.name) {
+    const parts = fields.name.trim().split(/\s+/);
+    body.firstName = parts[0] ?? '';
+    body.lastName = parts.slice(1).join(' ');
+    body.name = fields.name;
+  }
+  if (fields.email) body.email = fields.email;
+  if (fields.phone) body.phone = fields.phone;
+  if (fields.website) body.website = fields.website;
+  if (Object.keys(body).length === 0) return false;
+  try {
+    const res = await fetch(`${GHL_BASE_URL}/contacts/${contactId}`, {
+      method: 'PUT',
+      headers: HEADERS,
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.error(`[HL] contact update failed ${res.status}:`, (await res.text()).slice(0, 300));
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error('[HL] contact update threw:', err);
+    return false;
+  }
+}
+
+export type OpportunityKind = 'signup' | 'lead' | 'trial' | 'abandoned';
 
 export interface CreateOpportunityArgs {
   contactId: string;
@@ -111,8 +156,9 @@ export async function createOpportunity(args: CreateOpportunityArgs): Promise<{ 
     return { id: null };
   }
   const stageId =
-    args.kind === 'signup' ? SIGNUP_STAGE_ID :
-    args.kind === 'trial'  ? (TRIAL_STAGE_ID || SIGNUP_STAGE_ID) :
+    args.kind === 'signup'    ? SIGNUP_STAGE_ID :
+    args.kind === 'trial'     ? (TRIAL_STAGE_ID || SIGNUP_STAGE_ID) :
+    args.kind === 'abandoned' ? (ABANDONED_STAGE_ID || LEAD_STAGE_ID) :
     LEAD_STAGE_ID;
 
   const body: Record<string, unknown> = {
@@ -200,7 +246,7 @@ export async function pushSignupToHighlevel(args: {
   monthlyCostPerBranchGbp?: number;
   packageName?: string;
   kind: OpportunityKind;
-}): Promise<{ opportunityId: string | null }> {
+}): Promise<{ opportunityId: string | null; contactId: string | null }> {
   const contact = await upsertContact({
     name: args.name,
     email: args.email,
@@ -210,7 +256,7 @@ export async function pushSignupToHighlevel(args: {
     source: args.source,
     tags: args.tags,
   });
-  if (!contact.contactId) return { opportunityId: null };
+  if (!contact.contactId) return { opportunityId: null, contactId: null };
   const opp = await createOpportunity({
     contactId: contact.contactId,
     name: args.opportunityName,
@@ -219,5 +265,5 @@ export async function pushSignupToHighlevel(args: {
     packageName: args.packageName,
     kind: args.kind,
   });
-  return { opportunityId: opp.id };
+  return { opportunityId: opp.id, contactId: contact.contactId };
 }

--- a/backend/src/services/stripe.ts
+++ b/backend/src/services/stripe.ts
@@ -39,11 +39,15 @@ export function stripeConfigured(): boolean {
 }
 
 export interface CreateCheckoutSessionArgs {
-  userId: string;
   email: string;
   businessName: string;
-  garageId: string;
-  agreementId: string;
+  // Present for the legacy flow (account already exists). For the new deferred flow the
+  // account doesn't exist yet, so pendingSignupId is carried in the metadata instead and
+  // the setup_intent.succeeded webhook creates the account from it.
+  userId?: string;
+  garageId?: string;
+  agreementId?: string;
+  pendingSignupId?: string;
 }
 
 export const STRIPE_TRIAL_DAYS = TRIAL_DAYS;
@@ -57,13 +61,14 @@ export async function createAssistTrialCheckoutSession(args: CreateCheckoutSessi
     throw new Error('STRIPE_ASSIST_PRICE_ID is not configured');
   }
 
-  const metadata = {
-    userId:       args.userId,
-    garageId:     args.garageId,
-    agreementId:  args.agreementId,
+  const metadata: Record<string, string> = {
     businessName: args.businessName.slice(0, 100),
     kind: 'assist-trial',
   };
+  if (args.userId) metadata.userId = args.userId;
+  if (args.garageId) metadata.garageId = args.garageId;
+  if (args.agreementId) metadata.agreementId = args.agreementId;
+  if (args.pendingSignupId) metadata.pendingSignupId = args.pendingSignupId;
 
   return stripe.checkout.sessions.create({
     mode: 'subscription',
@@ -105,13 +110,14 @@ export async function createAssistTrialSubscription(args: CreateCheckoutSessionA
     throw new Error('STRIPE_ASSIST_PRICE_ID is not configured');
   }
 
-  const metadata = {
-    userId:       args.userId,
-    garageId:     args.garageId,
-    agreementId:  args.agreementId,
+  const metadata: Record<string, string> = {
     businessName: args.businessName.slice(0, 100),
     kind: 'assist-trial',
   };
+  if (args.userId) metadata.userId = args.userId;
+  if (args.garageId) metadata.garageId = args.garageId;
+  if (args.agreementId) metadata.agreementId = args.agreementId;
+  if (args.pendingSignupId) metadata.pendingSignupId = args.pendingSignupId;
 
   const customer = await stripe.customers.create({
     email: args.email,

--- a/prisma/migrations/20260709160000_add_pending_signup/migration.sql
+++ b/prisma/migrations/20260709160000_add_pending_signup/migration.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS "PendingSignup" (
+  "id" TEXT NOT NULL,
+  "businessName" TEXT NOT NULL,
+  "email" TEXT NOT NULL,
+  "name" TEXT,
+  "googlePlaceId" TEXT,
+  "branchAddress" TEXT,
+  "phoneNumber" TEXT,
+  "websiteUrl" TEXT,
+  "weeklyOpeningHours" JSONB,
+  "signToken" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "ghlOpportunityId" TEXT,
+  "ghlContactId" TEXT,
+  "signedByName" TEXT,
+  "signedByPosition" TEXT,
+  "signatureImage" TEXT,
+  "signedFromIp" TEXT,
+  "signedUserAgent" TEXT,
+  "templateSnapshot" TEXT,
+  "agreementVersion" TEXT,
+  "signedAt" TIMESTAMP(3),
+  "stripeCustomerId" TEXT,
+  "stripeSubscriptionId" TEXT,
+  "trialEndsAt" TIMESTAMP(3),
+  "createdGarageId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "PendingSignup_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "PendingSignup_signToken_key" ON "PendingSignup"("signToken");
+CREATE INDEX IF NOT EXISTS "PendingSignup_email_idx" ON "PendingSignup"("email");
+CREATE INDEX IF NOT EXISTS "PendingSignup_stripeCustomerId_idx" ON "PendingSignup"("stripeCustomerId");

--- a/prisma/migrations/20260709170000_pending_signup_prospect/migration.sql
+++ b/prisma/migrations/20260709170000_pending_signup_prospect/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "PendingSignup" ADD COLUMN IF NOT EXISTS "product" TEXT;
+ALTER TABLE "PendingSignup" ADD COLUMN IF NOT EXISTS "contactPhone" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -681,3 +681,57 @@ model Invoice {
   @@index([businessId, periodStart])
   @@index([status])
 }
+
+// A self-serve Assist signup that has NOT yet become a real account. Created when the
+// customer submits their garage details; the real Business/Garage/User/Agreement are
+// only created once they have signed the agreement AND confirmed a card (Stripe
+// setup_intent.succeeded). Until then we hold their details here and track them in
+// HighLevel's "Abandoned checkout" stage so no interested party is lost.
+model PendingSignup {
+  id            String   @id @default(uuid())
+  businessName  String
+  email         String
+  name          String?
+  googlePlaceId String?
+  product      String?  // assist | automate | connect | multibranch | custom
+  contactPhone String?  // contact phone captured on the scope step (non-Assist)
+
+  // Enriched from Google Places at submit time so we don't re-call Google on completion.
+  branchAddress      String?
+  phoneNumber        String?
+  websiteUrl         String?
+  weeklyOpeningHours Json?
+
+  // Magic-link sign token (single-use-ish; the pending row is the source of truth).
+  signToken String  @unique
+  status    String  @default("pending") // pending | signed | completed
+
+  // HighLevel — opportunity starts in "Abandoned checkout", moves to "Free trial live" on completion.
+  ghlOpportunityId String?
+  ghlContactId     String?
+
+  // Signature capture (transferred onto the real Agreement on completion).
+  signedByName     String?
+  signedByPosition String?
+  signatureImage   String?  @db.Text
+  signedFromIp     String?
+  signedUserAgent  String?
+  templateSnapshot String?  @db.Text
+  agreementVersion String?
+  signedAt         DateTime?
+
+  // Stripe trial — created when they sign; the webhook maps the confirmed card back here.
+  stripeCustomerId     String?
+  stripeSubscriptionId String?
+  trialEndsAt          DateTime?
+
+  // Set once the real account is provisioned (idempotency guard for the webhook).
+  createdGarageId String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  expiresAt DateTime
+
+  @@index([email])
+  @@index([stripeCustomerId])
+}


### PR DESCRIPTION
Reworks the self-serve Assist funnel: no account until the customer signs the agreement AND confirms a card; the whole journey is tracked in HighLevel (Abandoned checkout → Free trial live). Includes the PendingSignup model, prospect endpoints (with unique-placeholder contact so an opp is created from just a business name + update-by-id enrich), the account-on-card webhook, Choose-a-password → auto-login, and public-lead prospectId. Deployed + verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)