### PR TITLE
Fix: remove stray deviceTokensRouter import from server.ts

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -136,7 +136,6 @@ app.use('/api', publicLeadRouter);
 app.use('/api', livekitDemoRouter);
 app.use('/api', agreementsRouter);
 app.use('/api', supportRouter);
-app.use('/api', deviceTokensRouter);
 app.use('/api', templatesRouter);
 app.use('/api/webhooks', metaWhatsappWebhook);
 app.use('/api/webhooks', metaFacebookWebhook);


### PR DESCRIPTION
Removes an uncommitted push-router import that bled into the deferred-signup PR (module not on this branch). 🤖 Generated with [Claude Code](https://claude.com/claude-code)