### PR TITLE
Fix: remove remaining stray deviceTokensRouter import

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -39,7 +39,6 @@ import publicStatsRouter from './routes/public-stats.js';
 import publicLeadRouter from './routes/public-lead.js';
 import agreementsRouter from './routes/agreements.js';
 import supportRouter from './routes/support.js';
-import deviceTokensRouter from './routes/deviceTokens.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { initializeScheduledReports } from './utils/scheduler.js';
 import { startArrearsSweep } from './utils/arrears.js';


### PR DESCRIPTION
Second half of the fix — removes the import line (the earlier regex missed the ./ path). 🤖 Generated with [Claude Code](https://claude.com/claude-code)