### PR TITLE
Add Google tag to marketing site (Ads conversion tracking)

### DIFF
--- a/marketing-site/src/layouts/BaseLayout.astro
+++ b/marketing-site/src/layouts/BaseLayout.astro
@@ -51,6 +51,16 @@ const {
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://rsms.me/" />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-16449651971"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'AW-16449651971');
+    </script>
+
     <slot name="head" />
   </head>
 


### PR DESCRIPTION
Installs the Google tag (gtag.js AW-16449651971) site-wide via BaseLayout for Google Ads conversion tracking. 🤖 Generated with [Claude Code](https://claude.com/claude-code)