### PR TITLE
Google Ads conversion tracking (portal tag + trial-signup conversion)

### DIFF
--- a/app/components/TrialCardForm.tsx
+++ b/app/components/TrialCardForm.tsx
@@ -55,6 +55,12 @@ function CardForm({ resetToken, pendingSignupId }: { resetToken?: string | null;
       // Card confirmed inline (no 3-D Secure). For the deferred flow, create the account NOW
       // (returns a set-password token), then go to Choose-a-password → auto-login.
       setSucceeded(true);
+      // Google Ads conversion — a real, carded 14-day trial has started (Count=One, so Google
+      // de-dupes per click even if this ever fires more than once).
+      const w = window as unknown as { gtag?: (...args: unknown[]) => void };
+      if (typeof w.gtag === 'function') {
+        w.gtag('event', 'conversion', { send_to: 'AW-16449651971/8I8tCMHe7s0cEIOK56M9', value: 200, currency: 'GBP' });
+      }
       if (pendingSignupId && !resetToken) {
         try {
           const res = await fetch('/internal-api/public/signup-complete', {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import { headers } from "next/headers";
+import Script from "next/script";
 import "./globals.css";
 import Providers from "./providers";
 import AppShell from "./components/AppShell";
@@ -47,6 +48,14 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
+        {/* Google tag (gtag.js) — Google Ads conversion tracking */}
+        <Script src="https://www.googletagmanager.com/gtag/js?id=AW-16449651971" strategy="afterInteractive" />
+        <Script id="gtag-init" strategy="afterInteractive">{`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'AW-16449651971');
+        `}</Script>
         <Providers>
           <AppShell>{children}</AppShell>
         </Providers>


### PR DESCRIPTION
Installs the Google tag on the portal and fires the Sign-up conversion when a carded 14-day trial starts (in TrialCardForm on SetupIntent success). Marketing tag is on main (#327). Deployed + live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)