### PR TITLE
Enhanced conversions — send customer email with the Ads conversion

### DIFF
--- a/app/agreement/sign/page.tsx
+++ b/app/agreement/sign/page.tsx
@@ -297,7 +297,7 @@ function AgreementSignInner() {
                 Add your card to activate. You won’t be charged today — the trial is free for 14 days.
               </p>
               <div className="mt-4">
-                <TrialCardForm clientSecret={cardClientSecret} resetToken={cardResetToken} pendingSignupId={cardPendingId} />
+                <TrialCardForm clientSecret={cardClientSecret} resetToken={cardResetToken} pendingSignupId={cardPendingId} email={customerEmail} />
               </div>
             </div>
           ) : token ? (

--- a/app/components/TrialCardForm.tsx
+++ b/app/components/TrialCardForm.tsx
@@ -16,7 +16,7 @@ import {
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? '');
 
-function CardForm({ resetToken, pendingSignupId }: { resetToken?: string | null; pendingSignupId?: string | null }) {
+function CardForm({ resetToken, pendingSignupId, email }: { resetToken?: string | null; pendingSignupId?: string | null; email?: string | null }) {
   const stripe = useStripe();
   const elements = useElements();
   const [submitting, setSubmitting] = useState(false);
@@ -59,6 +59,10 @@ function CardForm({ resetToken, pendingSignupId }: { resetToken?: string | null;
       // de-dupes per click even if this ever fires more than once).
       const w = window as unknown as { gtag?: (...args: unknown[]) => void };
       if (typeof w.gtag === 'function') {
+        // Enhanced conversions: pass the customer's email (gtag normalises + hashes it before
+        // sending) so Google can match the conversion more accurately. Improves attribution only —
+        // the email is never exposed back to us.
+        if (email) w.gtag('set', 'user_data', { email });
         w.gtag('event', 'conversion', { send_to: 'AW-16449651971/8I8tCMHe7s0cEIOK56M9', value: 200, currency: 'GBP' });
       }
       if (pendingSignupId && !resetToken) {
@@ -116,7 +120,7 @@ function CardForm({ resetToken, pendingSignupId }: { resetToken?: string | null;
   );
 }
 
-export default function TrialCardForm({ clientSecret, resetToken, pendingSignupId }: { clientSecret: string; resetToken?: string | null; pendingSignupId?: string | null }) {
+export default function TrialCardForm({ clientSecret, resetToken, pendingSignupId, email }: { clientSecret: string; resetToken?: string | null; pendingSignupId?: string | null; email?: string | null }) {
   return (
     <Elements
       stripe={stripePromise}
@@ -132,7 +136,7 @@ export default function TrialCardForm({ clientSecret, resetToken, pendingSignupI
         },
       }}
     >
-      <CardForm resetToken={resetToken} pendingSignupId={pendingSignupId} />
+      <CardForm resetToken={resetToken} pendingSignupId={pendingSignupId} email={email} />
     </Elements>
   );
 }


### PR DESCRIPTION
Sets gtag user_data (email) before the Sign-up conversion for enhanced-conversion matching. Attribution only; hashed client-side. Deployed + live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)